### PR TITLE
OP new features

### DIFF
--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
@@ -73,6 +73,7 @@ public class Config {
 	public boolean use_abandonment_threshold = true;
 	public boolean mutate_on_competition_win = false;
 	public boolean separate_production_competitiveness = false;
+	public boolean use_explicit_price_utility = false;
 	public boolean use_price_only_utility = false;
 	public boolean use_normalised_price_competition = false;
 	public double mutation_interval = 0.01;

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
@@ -62,6 +62,7 @@ public class Config {
 	public boolean remove_negative_marginal_utility = false;
 	public boolean use_abandonment_threshold = true;
 	public boolean mutate_on_competition_win = false;
+	public boolean separate_production_competitiveness = false;
 	public double mutation_interval = 0.01;
 	public double MostCompetitorAFTProbability = 0.8;
 	public boolean averaged_residual_demand_per_cell = false;

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
@@ -55,6 +55,11 @@ public class Config {
 	public String waitingFlag_directories_path = "";
 	public String AFT_capital_adjustments = "";
 
+	// Production costs
+	public boolean use_production_costs = false;
+	public boolean spatial_production_costs = false;
+	public String costs_directory = "";
+
 	// Regionalisation
 	public boolean regionalization = false;
 	// CRAFTY Mechanisms
@@ -162,7 +167,11 @@ public class Config {
 				+ "|-> track_changes=" + track_changes + "\n" + "|-> export_LOGGER=" + export_LOGGER + "\n"
 				+ "|-> LOGGER_info=" + LOGGER_info + "\n" + "|-> LOGGER_warn=" + LOGGER_warn + "\n"
 				+ "|-> LOGGER_trace=" + LOGGER_trace + "\n" + "|-> map_output_years=" + map_output_years + "\n"
-				+ "|-> comments=" + comments + "\n" + "] \n\n";
+				+ "|-> comments=" + comments + "\n"
+				+ "|-> use_production_costs=" + use_production_costs + "\n"
+				+ "|-> spatial_production_costs=" + spatial_production_costs + "\n"
+				+ "|-> costs_directory=" + costs_directory + "\n"
+				+ "] \n\n";
 	}
 
 	// behevoir model

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
@@ -63,7 +63,8 @@ public class Config {
 	public boolean use_abandonment_threshold = true;
 	public boolean mutate_on_competition_win = false;
 	public boolean separate_production_competitiveness = false;
-	public boolean use_price_only_competition = false;
+	public boolean use_price_only_utility = false;
+	public boolean use_normalised_price_competition = false;
 	public double mutation_interval = 0.01;
 	public double MostCompetitorAFTProbability = 0.8;
 	public boolean averaged_residual_demand_per_cell = false;

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
@@ -63,6 +63,7 @@ public class Config {
 	public boolean use_abandonment_threshold = true;
 	public boolean mutate_on_competition_win = false;
 	public boolean separate_production_competitiveness = false;
+	public boolean use_price_only_competition = false;
 	public double mutation_interval = 0.01;
 	public double MostCompetitorAFTProbability = 0.8;
 	public boolean averaged_residual_demand_per_cell = false;

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/Config.java
@@ -60,6 +60,11 @@ public class Config {
 	public boolean spatial_production_costs = false;
 	public String costs_directory = "";
 
+	// Twinned AFTs
+	public boolean use_twinned_AFTs = false;
+	public boolean use_twinned_cost = false;
+	public double twinned_competition_rate = 1.0;
+
 	// Regionalisation
 	public boolean regionalization = false;
 	// CRAFTY Mechanisms

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/ConfigLoader.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/ConfigLoader.java
@@ -48,6 +48,7 @@ public class ConfigLoader {
 		config = loadConfig();
 		validateProductionCostConfig();
 		validateTwinnedAftConfig();
+		validatePriceUtilityConfig();
 		try {
 			loadExternalRScriptRunnerConfig();
 		} catch (IOException e) {
@@ -69,6 +70,13 @@ public class ConfigLoader {
 		}
 		if (config.twinned_competition_rate < 0.0 || config.twinned_competition_rate > 1.0) {
 			LOGGER.fatal("twinned_competition_rate must be in [0, 1], got: " + config.twinned_competition_rate);
+		}
+	}
+
+	static void validatePriceUtilityConfig() {
+		if (config == null) return;
+		if (config.use_explicit_price_utility && config.use_price_only_utility) {
+			LOGGER.fatal("use_explicit_price_utility and use_price_only_utility are mutually exclusive");
 		}
 	}
 

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/ConfigLoader.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/ConfigLoader.java
@@ -42,14 +42,31 @@ import java.nio.file.Paths;
 public class ConfigLoader {
 	public static String configPath;
 	public static Config config;
+	private static final CustomLogger LOGGER = new CustomLogger(ConfigLoader.class);
 
 	public static void init() {
 		config = loadConfig();
+		validateProductionCostConfig();
 		try {
 			loadExternalRScriptRunnerConfig();
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
+	}
+
+	static void validateProductionCostConfig() {
+		if (config == null) return;
+		if (!config.use_production_costs && config.spatial_production_costs) {
+			LOGGER.fatal("Cannot use spatial production costs when use_production_costs is false");
+		}
+	}
+
+	public static boolean isUseProductionCosts() {
+		return config != null && config.use_production_costs;
+	}
+
+	public static boolean isSpatialProductionCosts() {
+		return config != null && config.spatial_production_costs;
 	}
 
 	private static Config loadConfig() {

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/ConfigLoader.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/cli/ConfigLoader.java
@@ -47,6 +47,7 @@ public class ConfigLoader {
 	public static void init() {
 		config = loadConfig();
 		validateProductionCostConfig();
+		validateTwinnedAftConfig();
 		try {
 			loadExternalRScriptRunnerConfig();
 		} catch (IOException e) {
@@ -59,6 +60,24 @@ public class ConfigLoader {
 		if (!config.use_production_costs && config.spatial_production_costs) {
 			LOGGER.fatal("Cannot use spatial production costs when use_production_costs is false");
 		}
+	}
+
+	static void validateTwinnedAftConfig() {
+		if (config == null) return;
+		if (config.use_twinned_cost && !config.use_twinned_AFTs) {
+			LOGGER.fatal("Cannot use twinned cost when use_twinned_AFTs is false");
+		}
+		if (config.twinned_competition_rate < 0.0 || config.twinned_competition_rate > 1.0) {
+			LOGGER.fatal("twinned_competition_rate must be in [0, 1], got: " + config.twinned_competition_rate);
+		}
+	}
+
+	public static boolean isUseTwinnedAFTs() {
+		return config != null && config.use_twinned_AFTs;
+	}
+
+	public static boolean isUseTwinnedCost() {
+		return config != null && config.use_twinned_cost;
 	}
 
 	public static boolean isUseProductionCosts() {

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/AbstractAft.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/AbstractAft.java
@@ -56,8 +56,10 @@ public abstract class AbstractAft {
 	private double nfertCostPerHa = 0.0;
 	private double intensityCostPerHa = 0.0;
 
-	
-	
+	// Twinned AFT fields
+	private String twinLabel = null;
+	private double twinCost = 0.0;
+
 	public long getId() {
 		return id;
 	}
@@ -256,6 +258,26 @@ public abstract class AbstractAft {
 
 	public void setIntensityCostPerHa(double intensityCostPerHa) {
 		this.intensityCostPerHa = intensityCostPerHa;
+	}
+
+	public String getTwinLabel() {
+		return twinLabel;
+	}
+
+	public void setTwinLabel(String twinLabel) {
+		this.twinLabel = twinLabel;
+	}
+
+	public double getTwinCost() {
+		return twinCost;
+	}
+
+	public void setTwinCost(double twinCost) {
+		this.twinCost = twinCost;
+	}
+
+	public boolean hasTwin() {
+		return twinLabel != null && !twinLabel.isBlank();
 	}
 
 }

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/AbstractAft.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/AbstractAft.java
@@ -50,6 +50,12 @@ public abstract class AbstractAft {
 	protected Map<String, Map<String, Double>> sensitivity = new ConcurrentHashMap<>(); // <service,capital,exponent>
 	private int min_life_cycle = 0, max_life_cycle = Integer.MAX_VALUE;
 
+	// Production cost fields
+	private double nfertRate = 0.0;
+	private boolean irrigated = false;
+	private double nfertCostPerHa = 0.0;
+	private double intensityCostPerHa = 0.0;
+
 	
 	
 	public long getId() {
@@ -218,6 +224,38 @@ public abstract class AbstractAft {
 
 	public ConcurrentHashMap<String, Double> getCapital_adjustments() {
 		return capital_adjustments;
+	}
+
+	public double getNfertRate() {
+		return nfertRate;
+	}
+
+	public void setNfertRate(double nfertRate) {
+		this.nfertRate = nfertRate;
+	}
+
+	public boolean isIrrigated() {
+		return irrigated;
+	}
+
+	public void setIrrigated(boolean irrigated) {
+		this.irrigated = irrigated;
+	}
+
+	public double getNfertCostPerHa() {
+		return nfertCostPerHa;
+	}
+
+	public void setNfertCostPerHa(double nfertCostPerHa) {
+		this.nfertCostPerHa = nfertCostPerHa;
+	}
+
+	public double getIntensityCostPerHa() {
+		return intensityCostPerHa;
+	}
+
+	public void setIntensityCostPerHa(double intensityCostPerHa) {
+		this.intensityCostPerHa = intensityCostPerHa;
 	}
 
 }

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/AbstractCell.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/AbstractCell.java
@@ -36,6 +36,11 @@ public abstract class AbstractCell {
 	private ConcurrentHashMap<String, Double> landTax = new ConcurrentHashMap<>();
 	private ConcurrentHashMap<String, Double> capitalsAdjusment = new ConcurrentHashMap<>();
 
+	// Production cost storage (AFT label -> $/ha)
+	private ConcurrentHashMap<String, Double> nfertCosts = new ConcurrentHashMap<>();
+	private ConcurrentHashMap<String, Double> irrigationCosts = new ConcurrentHashMap<>();
+	private ConcurrentHashMap<String, Double> intensityCosts = new ConcurrentHashMap<>();
+
 	private double[] currentProd;
 	private double currentUtility;
 	String CurrentRegion;
@@ -205,6 +210,18 @@ public abstract class AbstractCell {
 
 	public ConcurrentHashMap<String, Double> getCapitalsAdjusment() {
 		return capitalsAdjusment;
+	}
+
+	public ConcurrentHashMap<String, Double> getNfertCosts() {
+		return nfertCosts;
+	}
+
+	public ConcurrentHashMap<String, Double> getIrrigationCosts() {
+		return irrigationCosts;
+	}
+
+	public ConcurrentHashMap<String, Double> getIntensityCosts() {
+		return intensityCosts;
 	}
 
 }

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Aft.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Aft.java
@@ -52,6 +52,9 @@ public class Aft extends AbstractAft {
 					* (1 + ConfigLoader.config.mutation_interval * (2 * new Random().nextDouble() - 1));
 			this.giveUpProbabilty = other.giveUpProbabilty
 					* (1 + ConfigLoader.config.mutation_interval * (2 * new Random().nextDouble() - 1));
+
+			setTwinLabel(other.getTwinLabel());
+			setTwinCost(other.getTwinCost());
 		}
 
 	}

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Cell.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Cell.java
@@ -100,6 +100,20 @@ public class Cell extends AbstractCell {
 		return product * a.getProductivityLevel().get(serviceName);
 	}
 
+	public double productionCost(Aft a) {
+		if (a == null || !a.isInteract() || !ConfigLoader.isUseProductionCosts()) {
+			return 0.0;
+		}
+		double cost = getIrrigationCosts().getOrDefault(a.getLabel(), 0.0);
+		if (ConfigLoader.isSpatialProductionCosts()) {
+			cost += getNfertCosts().getOrDefault(a.getLabel(), 0.0)
+					+ getIntensityCosts().getOrDefault(a.getLabel(), 0.0);
+		} else {
+			cost += a.getNfertCostPerHa() + a.getIntensityCostPerHa();
+		}
+		return cost;
+	}
+
 	public void calculateCurrentProductivity() {
 		for (int i = 0; i < ServiceSet.getServicesList().size(); i++) {
 			getCurrentProd()[i] = productivity(getOwner(), ServiceSet.getServicesList().get(i));

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Cell.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Cell.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import de.cesr.crafty.core.cli.ConfigLoader;
 import de.cesr.crafty.core.dataLoader.serivces.ServiceSet;
+import de.cesr.crafty.core.updaters.CapitalUpdater;
 import de.cesr.crafty.core.output.Listener;
 import de.cesr.crafty.core.output.Tracker;
 import de.cesr.crafty.core.updaters.Timestep;
@@ -51,8 +52,26 @@ public class Cell extends AbstractCell {
 	public double productivity(Aft a, String serviceName) {
 		if (a == null || !a.isInteract())
 			return 0.0;
-		if (ConfigLoader.config.separate_production_competitiveness)
-			return a.getProductivityLevel().get(serviceName);
+		if (ConfigLoader.config.separate_production_competitiveness) {
+			final Map<String, Double> exps = a.getSensByService().get(serviceName);
+			if (exps == null || exps.isEmpty())
+				return a.getProductivityLevel().get(serviceName);
+			double product = 1.0;
+			for (var e : exps.entrySet()) {
+				if (!CapitalUpdater.isSuitability(e.getKey()))
+					continue;
+				final double p = e.getValue();
+				if (p == 0.0)
+					continue;
+				final double capVal = (getCapitals().getOrDefault(e.getKey(), 0.)
+						* (1 + getCapitalsAdjusment().getOrDefault(e.getKey(), 0.)));
+				if (p == 1.0)
+					product *= capVal;
+				else
+					product *= Math.pow(capVal, p);
+			}
+			return product * a.getProductivityLevel().get(serviceName);
+		}
 		return competitiveness(a, serviceName);
 	}
 

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Cell.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Cell.java
@@ -51,6 +51,14 @@ public class Cell extends AbstractCell {
 	public double productivity(Aft a, String serviceName) {
 		if (a == null || !a.isInteract())
 			return 0.0;
+		if (ConfigLoader.config.separate_production_competitiveness)
+			return a.getProductivityLevel().get(serviceName);
+		return competitiveness(a, serviceName);
+	}
+
+	public double competitiveness(Aft a, String serviceName) {
+		if (a == null || !a.isInteract())
+			return 0.0;
 
 		final Map<String, Double> exps = a.getSensByService().get(serviceName);
 		if (exps == null || exps.isEmpty())
@@ -63,7 +71,7 @@ public class Cell extends AbstractCell {
 			if (p == 0.0)
 				continue;
 			final double capVal = (getCapitals().getOrDefault(e.getKey(), 0.)
-					* (1 + getCapitalsAdjusment().getOrDefault(e.getKey(), 0.))); // assumes present
+					* (1 + getCapitalsAdjusment().getOrDefault(e.getKey(), 0.)));
 			if (p == 1.0)
 				product *= capVal;
 			else

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
@@ -66,7 +66,7 @@ public class Competitiveness {
 			return utilityUseOnlyPrice(c, a, r);
 		}
 		if (ConfigLoader.config.use_cell_level_taxes) {
-			utilityUseMarginalWithTexes(c, a, r);
+			return utilityUseMarginalWithTexes(c, a, r);
 		}
 		return utilityUseMarginal(c, a, r);
 	}
@@ -100,7 +100,7 @@ public class Competitiveness {
 		if (a == null || !a.isInteract()) {
 			return 0;
 		}
-		return ServiceSet.getServicesList().stream().mapToDouble(serviceName -> {
+		double revenue = ServiceSet.getServicesList().stream().mapToDouble(serviceName -> {
 			Service service = r.R.getServicesHash().get(serviceName);
 			double currentWeight = service.getWeights().get(Timestep.getCurrentYear());
 			double result = currentWeight * c.competitiveness(a, serviceName);
@@ -109,6 +109,7 @@ public class Competitiveness {
 			}
 			return result;
 		}).sum();
+		return revenue - c.productionCost(a);
 	}
 
 //	public static Aft mostCompetitiveAgent(Cell c, Collection<Aft> setAfts, RegionalModelRunner r) {

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
@@ -83,7 +83,7 @@ public class Competitiveness {
 		// u= sum_s[ (ms+ts*d0)ps]+ land_ts*abs(u1)
 		return ServiceSet.getServicesList().stream()
 				.mapToDouble(serviceName -> (c.getServicesTax().getOrDefault(serviceName, 0d)
-						+ r.getMarginal().get(serviceName)) * c.productivity(a, serviceName))
+						+ r.getMarginal().get(serviceName)) * c.competitiveness(a, serviceName))
 				.sum() + c.getLandTax().getOrDefault(a.getLabel(), 0d);
 	}
 
@@ -95,7 +95,7 @@ public class Competitiveness {
 		return ServiceSet.getServicesList().stream()
 				.mapToDouble(serviceName -> (c.getServicesTax().getOrDefault(serviceName, 1d)
 						* (r.initial_service_gaps.get(serviceName)) + r.getMarginal().get(serviceName))
-						* c.productivity(a, serviceName))
+						* c.competitiveness(a, serviceName))
 				.sum()
 				+ c.getLandTax().getOrDefault(a.getLabel(), 0d)
 						* (r.initialutilityAverage.getOrDefault(a.getLabel(), 1d));
@@ -113,7 +113,7 @@ public class Competitiveness {
 			double currentWeight = service.getWeights().get(Timestep.getCurrentYear());
 			double initialWeight = service.getWeights().get(Timestep.getStartYear());
 
-			double result = (currentWeight / initialWeight) * c.productivity(a, serviceName);
+			double result = (currentWeight / initialWeight) * c.competitiveness(a, serviceName);
 			if (Double.isNaN(result) || Double.isInfinite(result)) {
 				return 0.0;
 			}

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
@@ -133,13 +133,34 @@ public class Competitiveness {
 			return;
 		}
 		if (makeCompetition(c, competitor)) {
-			if (ConfigLoader.config.use_normalised_price_competition) {
-				landUsechangeNormalisedPriceUtility(c, competitor, r);
-			} else if (AftCategorised.useCategorisationGivIn && CellBehaviourUpdater.behaviourUsed) {
-				landUsechangeNormalisedUtility(c, competitor, r);
-			} else {
-				landUsechange(c, competitor, r);
+			dispatchLandUseChange(c, competitor, r);
+		}
+	}
+
+	private static void dispatchLandUseChange(Cell c, Aft competitor, RegionalModelRunner r) {
+		if (ConfigLoader.config.use_normalised_price_competition) {
+			landUsechangeNormalisedPriceUtility(c, competitor, r);
+		} else if (AftCategorised.useCategorisationGivIn && CellBehaviourUpdater.behaviourUsed) {
+			landUsechangeNormalisedUtility(c, competitor, r);
+		} else {
+			landUsechange(c, competitor, r);
+		}
+	}
+
+	static void twinCompetition(Cell c, RegionalModelRunner r) {
+		Aft owner = c.getOwner();
+		if (owner == null || !owner.isInteract() || !owner.hasTwin()) return;
+		Aft twin = AFTsLoader.getAftHash().get(owner.getTwinLabel());
+		if (twin == null || !twin.isInteract() || !makeCompetition(c, twin)) return;
+
+		if (ConfigLoader.config.use_twinned_cost) {
+			double uTwin = utility(c, twin, r);
+			double uOwner = c.getCurrentUtility();
+			if (uTwin > 0 && uTwin > uOwner + twin.getTwinCost()) {
+				takeOverAcell(c, twin, r);
 			}
+		} else {
+			dispatchLandUseChange(c, twin, r);
 		}
 	}
 

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
@@ -62,12 +62,12 @@ import de.cesr.crafty.core.utils.general.DeterministicRandom;
 
 public class Competitiveness {
 
-	private static final boolean COUPLED_WITH_PLUM = ConfigLoader.config.COUPLED_WITH_PLUM;
+	private static final boolean use_price_only = ConfigLoader.config.use_price_only_competition;
 	private static final boolean use_cell_level_taxes = ConfigLoader.config.use_cell_level_taxes;
 	
 
 	static double utility(Cell c, Aft a, RegionalModelRunner r) {
-		if (COUPLED_WITH_PLUM) {
+		if (use_price_only) {
 			return utilityUseOnlyPrice(c, a, r);
 		}
 		if (use_cell_level_taxes) {
@@ -101,7 +101,6 @@ public class Competitiveness {
 						* (r.initialutilityAverage.getOrDefault(a.getLabel(), 1d));
 	}
 
-//	## only in coupling withPlum
 	private static double utilityUseOnlyPrice(Cell c, Aft a, RegionalModelRunner r) {
 		if (a == null || !a.isInteract()) {
 			return 0;

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-
 import de.cesr.crafty.core.cli.ConfigLoader;
 import de.cesr.crafty.core.dataLoader.afts.AFTsLoader;
 import de.cesr.crafty.core.dataLoader.afts.AftCategorised;
@@ -62,15 +61,11 @@ import de.cesr.crafty.core.utils.general.DeterministicRandom;
 
 public class Competitiveness {
 
-	private static final boolean use_price_only = ConfigLoader.config.use_price_only_competition;
-	private static final boolean use_cell_level_taxes = ConfigLoader.config.use_cell_level_taxes;
-	
-
 	static double utility(Cell c, Aft a, RegionalModelRunner r) {
-		if (use_price_only) {
+		if (ConfigLoader.config.use_price_only_utility) {
 			return utilityUseOnlyPrice(c, a, r);
 		}
-		if (use_cell_level_taxes) {
+		if (ConfigLoader.config.use_cell_level_taxes) {
 			utilityUseMarginalWithTexes(c, a, r);
 		}
 		return utilityUseMarginal(c, a, r);
@@ -105,21 +100,15 @@ public class Competitiveness {
 		if (a == null || !a.isInteract()) {
 			return 0;
 		}
-
-		double sum = ServiceSet.getServicesList().stream().mapToDouble(serviceName -> {
+		return ServiceSet.getServicesList().stream().mapToDouble(serviceName -> {
 			Service service = r.R.getServicesHash().get(serviceName);
-
 			double currentWeight = service.getWeights().get(Timestep.getCurrentYear());
-			double initialWeight = service.getWeights().get(Timestep.getStartYear());
-
-			double result = (currentWeight / initialWeight) * c.competitiveness(a, serviceName);
+			double result = currentWeight * c.competitiveness(a, serviceName);
 			if (Double.isNaN(result) || Double.isInfinite(result)) {
 				return 0.0;
 			}
 			return result;
 		}).sum();
-
-		return sum;
 	}
 
 //	public static Aft mostCompetitiveAgent(Cell c, Collection<Aft> setAfts, RegionalModelRunner r) {
@@ -143,8 +132,9 @@ public class Competitiveness {
 			return;
 		}
 		if (makeCompetition(c, competitor)) {
-
-			if (AftCategorised.useCategorisationGivIn && CellBehaviourUpdater.behaviourUsed) {
+			if (ConfigLoader.config.use_normalised_price_competition) {
+				landUsechangeNormalisedPriceUtility(c, competitor, r);
+			} else if (AftCategorised.useCategorisationGivIn && CellBehaviourUpdater.behaviourUsed) {
 				landUsechangeNormalisedUtility(c, competitor, r);
 			} else {
 				landUsechange(c, competitor, r);
@@ -203,7 +193,7 @@ public class Competitiveness {
 		}
 		if (c.getOwner() == null || c.getOwner().isAbandoned()) {
 			if (uC >= r.getDistributionMeanY().get(competitor.getLabel())) {
-				takeOverAcell(c, competitor);
+				takeOverAcell(c, competitor, r);
 			}
 			return;
 		}
@@ -214,7 +204,7 @@ public class Competitiveness {
 				: 0;
 
 		if ((uC - uO > nbr) && uC > 0) {
-			takeOverAcell(c, competitor);
+			takeOverAcell(c, competitor, r);
 		}
 	}
 
@@ -229,34 +219,67 @@ public class Competitiveness {
 
 		if (c.getOwner() == null || c.getOwner().isAbandoned()) {
 			if (uC > 0) {
-				takeOverAcell(c, competitor);
+				takeOverAcell(c, competitor, r);
 			}
 			return;
 		}
 
 		double uO = (c.getCurrentUtility() - r.getMinUtility()) / (r.getMaxUtility() - r.getMinUtility());
 
-		double giveIn = 0;
-		boolean sameCategories = c.getOwner().category.getName().equals(competitor.category.getName());
-		boolean sameIntesity = c.getOwner().category.getIntensityLevel() == (competitor.category.getIntensityLevel());
-
-		if (!sameCategories || (sameCategories && sameIntesity)) {
-			giveIn = giveInThreshold(c, competitor);
-		} else {
-			if (CellBehaviourUpdater.cellsBehevoir.get(c) != null) {
-				giveIn = CellBehaviourUpdater.cellsBehevoir.get(c).give_In(competitor);
-			}
-		}
+		double giveIn = effectiveGiveIn(c, competitor);
 		if ((uC > uO + giveIn) && uC > 0) {
 
-			takeOverAcell(c, competitor);
+			takeOverAcell(c, competitor, r);
 		}
 	}
 
-	private static void takeOverAcell(Cell c, Aft newOwner) {
+	private static double effectiveGiveIn(Cell c, Aft competitor) {
+		boolean sameCategories = c.getOwner().category.getName()
+				.equals(competitor.category.getName());
+		boolean sameIntensity = c.getOwner().category.getIntensityLevel()
+				== competitor.category.getIntensityLevel();
+
+		if (!sameCategories || sameIntensity) {
+			return giveInThreshold(c, competitor);
+		}
+		CellBehaviour behaviour = CellBehaviourUpdater.cellsBehevoir.get(c);
+		if (behaviour != null) {
+			return behaviour.give_In(competitor);
+		}
+		return 0;
+	}
+
+	private static void landUsechangeNormalisedPriceUtility(Cell c, Aft competitor, RegionalModelRunner r) {
+		if (c.getOwner() == competitor) {
+			return;
+		}
+		double uC = utility(c, competitor, r);
+		if (uC <= 0) {
+			return;
+		}
+		if (c.getOwner() == null || c.getOwner().isAbandoned()) {
+			takeOverAcell(c, competitor, r);
+			return;
+		}
+		double uO = c.getCurrentUtility();
+		double normDiff = (uC - uO) / (Math.abs(uC) + Math.abs(uO));
+
+		double giveIn;
+		if (AftCategorised.useCategorisationGivIn && CellBehaviourUpdater.behaviourUsed) {
+			giveIn = effectiveGiveIn(c, competitor);
+		} else {
+			giveIn = giveInThreshold(c, competitor);
+		}
+		if (normDiff > giveIn) {
+			takeOverAcell(c, competitor, r);
+		}
+	}
+
+	private static void takeOverAcell(Cell c, Aft newOwner, RegionalModelRunner r) {
 		String oldOwner = c.getOwner() != null ? c.getOwner().getLabel() : "Abandoned";
 
 		c.setOwner(ConfigLoader.config.mutate_on_competition_win ? new Aft(newOwner) : newOwner);//
+		c.setCurrentUtility(utility(c, c.getOwner(), r));
 //		CellsUpdater.decesionsNewOwner.put(c, newOwner);
 		c.setOwnerLifeCounter(1);
 		Listener.landUseChangeCounter.getAndIncrement();

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/Competitiveness.java
@@ -62,6 +62,9 @@ import de.cesr.crafty.core.utils.general.DeterministicRandom;
 public class Competitiveness {
 
 	static double utility(Cell c, Aft a, RegionalModelRunner r) {
+		if (ConfigLoader.config.use_explicit_price_utility) {
+			return utilityUseExplicitPrice(c, a, r);
+		}
 		if (ConfigLoader.config.use_price_only_utility) {
 			return utilityUseOnlyPrice(c, a, r);
 		}
@@ -96,20 +99,32 @@ public class Competitiveness {
 						* (r.initialutilityAverage.getOrDefault(a.getLabel(), 1d));
 	}
 
-	private static double utilityUseOnlyPrice(Cell c, Aft a, RegionalModelRunner r) {
+	private static double priceBasedUtility(Cell c, Aft a, RegionalModelRunner r,
+			boolean normaliseToBaseline, boolean subtractCosts) {
 		if (a == null || !a.isInteract()) {
 			return 0;
 		}
 		double revenue = ServiceSet.getServicesList().stream().mapToDouble(serviceName -> {
 			Service service = r.R.getServicesHash().get(serviceName);
-			double currentWeight = service.getWeights().get(Timestep.getCurrentYear());
-			double result = currentWeight * c.competitiveness(a, serviceName);
+			double weight = service.getWeights().get(Timestep.getCurrentYear());
+			if (normaliseToBaseline) {
+				weight = weight / service.getWeights().get(Timestep.getStartYear());
+			}
+			double result = weight * c.competitiveness(a, serviceName);
 			if (Double.isNaN(result) || Double.isInfinite(result)) {
 				return 0.0;
 			}
 			return result;
 		}).sum();
-		return revenue - c.productionCost(a);
+		return subtractCosts ? revenue - c.productionCost(a) : revenue;
+	}
+
+	private static double utilityUseExplicitPrice(Cell c, Aft a, RegionalModelRunner r) {
+		return priceBasedUtility(c, a, r, false, true);
+	}
+
+	private static double utilityUseOnlyPrice(Cell c, Aft a, RegionalModelRunner r) {
+		return priceBasedUtility(c, a, r, true, false);
 	}
 
 //	public static Aft mostCompetitiveAgent(Cell c, Collection<Aft> setAfts, RegionalModelRunner r) {

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/RegionalModelRunner.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/RegionalModelRunner.java
@@ -204,6 +204,13 @@ public class RegionalModelRunner {
 		// Cache everything locally (cheaper than repeated virtual calls)
 		final var cells = R.getCells(); // ConcurrentHashMap<?, Cell>
 
+		if (ConfigLoader.config.use_price_only_utility) {
+			RegionalModelRunner self = this;
+			cells.forEach(100_000, (k, c) ->
+				c.setCurrentUtility(Competitiveness.utility(c, c.getOwner(), self)));
+			return;
+		}
+
 		if (!ConfigLoader.config.use_cell_level_taxes) {
 			// Snapshot services once
 			final List<String> servicesList = ServiceSet.getServicesList();

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/RegionalModelRunner.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/RegionalModelRunner.java
@@ -208,7 +208,7 @@ public class RegionalModelRunner {
 		// Cache everything locally (cheaper than repeated virtual calls)
 		final var cells = R.getCells(); // ConcurrentHashMap<?, Cell>
 
-		if (ConfigLoader.config.use_price_only_utility) {
+		if (ConfigLoader.config.use_explicit_price_utility || ConfigLoader.config.use_price_only_utility) {
 			RegionalModelRunner self = this;
 			cells.forEach(100_000, (k, c) ->
 				c.setCurrentUtility(Competitiveness.utility(c, c.getOwner(), self)));

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/RegionalModelRunner.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/RegionalModelRunner.java
@@ -219,7 +219,7 @@ public class RegionalModelRunner {
 		return ServiceSet.getServicesList().stream()
 				.mapToDouble(serviceName -> (c.getServicesTax().getOrDefault(serviceName, 1d)
 						* (initial_service_gaps.get(serviceName)) + getMarginal().get(serviceName))
-						* c.productivity(c.getOwner(), serviceName))
+						* c.competitiveness(c.getOwner(), serviceName))
 				.sum()
 				+ c.getLandTax().getOrDefault(c.getOwnerName(), 0d)
 						* (initialutilityAverage.getOrDefault(c.getOwnerName(), 1d));
@@ -245,7 +245,7 @@ public class RegionalModelRunner {
 
 		double u = owner.getCachedLandTax();
 		for (int i = 0; i < services.length; i++) {
-			u += coeff[i] * c.productivity(owner, services[i]);
+			u += coeff[i] * c.competitiveness(owner, services[i]);
 		}
 		return u;
 	}

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/RegionalModelRunner.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/crafty/RegionalModelRunner.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import de.cesr.crafty.core.cli.ConfigLoader;
 import de.cesr.crafty.core.cli.CustomLogger;
@@ -127,6 +128,9 @@ public class RegionalModelRunner {
 		}
 		try (var t = profiler.section("takeOverMaskedCellByCategories")) {
 			takeOverMaskedCellByCategories();
+		}
+		try (var t = profiler.section("twinnedCompetition")) {
+			twinnedCompetition();
 		}
 		try (var t = profiler.section("giveUp")) {
 			giveUp();
@@ -435,6 +439,48 @@ public class RegionalModelRunner {
 						for (int i = 0; i < ServiceSet.getServicesList().size(); i++) {
 							after.merge(ServiceSet.getServicesList().get(i), c.getCurrentProd()[i], Double::sum);
 						}
+					}
+				});
+			}
+			after.forEach((key, value) -> getRegionalSupply().merge(key, value - before.get(key), Double::sum));
+			computeMarginal();
+		});
+	}
+
+	private void twinnedCompetition() {
+		if (!ConfigLoader.config.use_twinned_AFTs) return;
+
+		long runSeed = ConfigLoader.config.longSeedID.get();
+		int year = Timestep.getCurrentYear();
+
+		List<Cell> seed = R.getCells().values().stream()
+				.filter(c -> {
+					Aft owner = c.getOwner();
+					return owner != null && owner.isInteract() && owner.hasTwin()
+							&& DeterministicRandom.randomBoolean(runSeed, year,
+									DeterministicRandom.Process.CELL_SELECTION_TWIN_COMPETITION,
+									DeterministicRandom.stableCellKey(c), 0L, 0,
+									ConfigLoader.config.twinned_competition_rate);
+				})
+				.collect(Collectors.toList());
+
+		if (seed.isEmpty()) return;
+
+		List<ConcurrentHashMap<String, Cell>> subsubsets = Utils.splitIntoSubsets(seed,
+				ConfigLoader.config.marginal_utility_calculations_per_tick);
+
+		subsubsets.forEach(subsubset -> {
+			ConcurrentHashMap<String, Double> before = new ConcurrentHashMap<>();
+			ConcurrentHashMap<String, Double> after = new ConcurrentHashMap<>();
+			if (subsubset != null) {
+				subsubset.values().parallelStream().forEach(c -> {
+					for (int i = 0; i < ServiceSet.getServicesList().size(); i++) {
+						before.merge(ServiceSet.getServicesList().get(i), c.getCurrentProd()[i], Double::sum);
+					}
+					Competitiveness.twinCompetition(c, this);
+					c.calculateCurrentProductivity();
+					for (int i = 0; i < ServiceSet.getServicesList().size(); i++) {
+						after.merge(ServiceSet.getServicesList().get(i), c.getCurrentProd()[i], Double::sum);
 					}
 				});
 			}

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/dataLoader/CsvKind.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/dataLoader/CsvKind.java
@@ -27,6 +27,24 @@ import java.util.Map;
 
 public enum CsvKind {
 
+	NFERT_COST {
+		@Override
+		void apply(String line, Map<String, Integer> index) {
+			CsvProcessors.associateNfertCostsToCells(index, line);
+		}
+	},
+	IRRIGATION_COST {
+		@Override
+		void apply(String line, Map<String, Integer> index) {
+			CsvProcessors.associateIrrigationCostToCells(index, line);
+		}
+	},
+	INTENSITY_COST {
+		@Override
+		void apply(String line, Map<String, Integer> index) {
+			CsvProcessors.associateIntensityCostsToCells(index, line);
+		}
+	},
 	CAPITALS {
 		@Override
 		void apply(String line, Map<String, Integer> index) {

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/dataLoader/CsvProcessors.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/dataLoader/CsvProcessors.java
@@ -22,6 +22,7 @@ import de.cesr.crafty.core.dataLoader.afts.AFTsLoader;
 import de.cesr.crafty.core.dataLoader.land.CellsLoader;
 import de.cesr.crafty.core.dataLoader.serivces.ServiceSet;
 import de.cesr.crafty.core.updaters.CapitalUpdater;
+import de.cesr.crafty.core.updaters.ProductionCostUpdater;
 import de.cesr.crafty.core.utils.general.Utils;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.AddCellToColumnException;
@@ -323,6 +324,81 @@ public class CsvProcessors {
 		}
 
 		return matrixMap;
+	}
+
+	static void associateNfertCostsToCells(Map<String, Integer> indexof, String data) {
+		String[] row = COMMA.split(data, -1);
+		int x = (int) Utils.sToD(row[indexof.get("X")]);
+		int y = (int) Utils.sToD(row[indexof.get("Y")]);
+
+		Cell c = CellsLoader.getCell(x, y);
+		if (c == null) {
+			return;
+		}
+
+		for (String aftLabel : ProductionCostUpdater.getNfertAftLabels()) {
+			Integer col = indexof.get(aftLabel.toUpperCase());
+			if (col == null) {
+				continue;
+			}
+			if (col < row.length) {
+				double costValue = Utils.sToD(row[col]);
+				c.getNfertCosts().put(aftLabel, costValue);
+			}
+		}
+	}
+
+	static void associateIrrigationCostToCells(Map<String, Integer> indexof, String data) {
+		String[] row = COMMA.split(data, -1);
+		int x = (int) Utils.sToD(row[indexof.get("X")]);
+		int y = (int) Utils.sToD(row[indexof.get("Y")]);
+
+		Cell c = CellsLoader.getCell(x, y);
+		if (c == null) {
+			return;
+		}
+
+		Integer singleCol = indexof.get("IRRIGATION_COST");
+		if (singleCol != null && singleCol < row.length) {
+			double costValue = Utils.sToD(row[singleCol]);
+			for (String aftLabel : ProductionCostUpdater.getIrrigatedAftLabels()) {
+				c.getIrrigationCosts().put(aftLabel, costValue);
+			}
+			return;
+		}
+
+		for (String aftLabel : ProductionCostUpdater.getIrrigatedAftLabels()) {
+			Integer col = indexof.get(aftLabel.toUpperCase());
+			if (col == null) {
+				continue;
+			}
+			if (col < row.length) {
+				double costValue = Utils.sToD(row[col]);
+				c.getIrrigationCosts().put(aftLabel, costValue);
+			}
+		}
+	}
+
+	static void associateIntensityCostsToCells(Map<String, Integer> indexof, String data) {
+		String[] row = COMMA.split(data, -1);
+		int x = (int) Utils.sToD(row[indexof.get("X")]);
+		int y = (int) Utils.sToD(row[indexof.get("Y")]);
+
+		Cell c = CellsLoader.getCell(x, y);
+		if (c == null) {
+			return;
+		}
+
+		for (String aftLabel : ProductionCostUpdater.getIntensityAftLabels()) {
+			Integer col = indexof.get(aftLabel.toUpperCase());
+			if (col == null) {
+				continue;
+			}
+			if (col < row.length) {
+				double costValue = Utils.sToD(row[col]);
+				c.getIntensityCosts().put(aftLabel, costValue);
+			}
+		}
 	}
 
 }

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/dataLoader/afts/AFTsLoader.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/dataLoader/afts/AFTsLoader.java
@@ -326,6 +326,19 @@ public class AFTsLoader extends HashSet<Aft> {
 					int max = Utils.sToI(csv.get("max_life_cycle").get(i));
 					a.setMax_life_cycle(max > 0 ? max : Integer.MAX_VALUE);
 				}
+				if (csv.containsKey("Nfert_rate")) {
+					a.setNfertRate(Utils.sToD(csv.get("Nfert_rate").get(i)));
+				}
+				if (csv.containsKey("Irrigated")) {
+					String val = csv.get("Irrigated").get(i).trim();
+					try {
+						a.setIrrigated(Integer.parseInt(val) == 1);
+					} catch (NumberFormatException e) {
+						LOGGER.warn("Unrecognised Irrigated value '" + val
+								+ "' for AFT " + label + ", defaulting to false (rainfed)");
+						a.setIrrigated(false);
+					}
+				}
 			}
 		}
 	}

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/dataLoader/afts/AFTsLoader.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/dataLoader/afts/AFTsLoader.java
@@ -339,6 +339,42 @@ public class AFTsLoader extends HashSet<Aft> {
 						a.setIrrigated(false);
 					}
 				}
+			if (csv.containsKey("Twin")) {
+				String twin = csv.get("Twin").get(i).trim();
+				a.setTwinLabel(twin.isEmpty() ? null : twin);
+			}
+			if (csv.containsKey("Twin_cost")) {
+				a.setTwinCost(Utils.sToD(csv.get("Twin_cost").get(i)));
+			}
+			}
+		}
+
+		if (ConfigLoader.config.use_twinned_AFTs && !csv.containsKey("Twin")) {
+			LOGGER.fatal("use_twinned_AFTs is true but 'Twin' column is missing from AFTsMetaData");
+		}
+		if (ConfigLoader.config.use_twinned_cost && !csv.containsKey("Twin_cost")) {
+			LOGGER.fatal("use_twinned_cost is true but 'Twin_cost' column is missing from AFTsMetaData");
+		}
+
+		for (Aft a : hashAFTs.values()) {
+			if (!a.hasTwin()) continue;
+			String label = a.getLabel();
+			String twin = a.getTwinLabel();
+
+			if (twin.equals(label)) {
+				LOGGER.warn("AFT '" + label + "' names itself as its own twin — clearing twin");
+				a.setTwinLabel(null);
+				continue;
+			}
+
+			Aft resolved = hashAFTs.get(twin);
+			if (resolved == null) {
+				LOGGER.warn("AFT '" + label + "' names twin '" + twin + "' which does not exist — clearing twin");
+				a.setTwinLabel(null);
+			} else if (!resolved.isInteract()) {
+				LOGGER.warn("AFT '" + label + "' names twin '" + twin
+						+ "' which is not an interacting AFT (type=" + resolved.getType() + ") — clearing twin");
+				a.setTwinLabel(null);
 			}
 		}
 	}

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/modelRunner/ModelRunner.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/modelRunner/ModelRunner.java
@@ -20,6 +20,7 @@ import de.cesr.crafty.core.updaters.Capital_Degradation_Updater;
 import de.cesr.crafty.core.updaters.CellBehaviourUpdater;
 import de.cesr.crafty.core.updaters.FlagUpdater;
 import de.cesr.crafty.core.updaters.LandMaskUpdater;
+import de.cesr.crafty.core.updaters.ProductionCostUpdater;
 import de.cesr.crafty.core.updaters.RegionsModelRunnerUpdater;
 import de.cesr.crafty.core.updaters.ServicesUpdater;
 import de.cesr.crafty.core.updaters.SupplyUpdater;
@@ -90,6 +91,7 @@ public class ModelRunner extends AbstractModelRunner {
 	public static CellsLoader cellsSet;
 	public static CapitalUpdater capitalUpdater;
 	public static AftsUpdater aftsUpdater;
+	public static ProductionCostUpdater productionCostUpdater;
 	private static Capital_Degradation_Updater capital_Degradation_Updater;
 	public RegionsModelRunnerUpdater regionsModelRunnerUpdater;
 
@@ -101,12 +103,14 @@ public class ModelRunner extends AbstractModelRunner {
 		aftsUpdater = new AftsUpdater();
 		cellsSet = new CellsLoader();
 		capitalUpdater.step();
+		productionCostUpdater = new ProductionCostUpdater();
 		capital_Degradation_Updater = new Capital_Degradation_Updater();
 		regionsModelRunnerUpdater=new RegionsModelRunnerUpdater();
 		getScheduled().clear();
 		getScheduled().add(new FlagUpdater());
 		getScheduled().add(new ServicesUpdater());
 		getScheduled().add(capitalUpdater);
+		getScheduled().add(productionCostUpdater);
 		getScheduled().add(aftsUpdater);
 		getScheduled().add(new CellBehaviourUpdater());
 		getScheduled().add(new LandMaskUpdater());

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/updaters/CapitalUpdater.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/updaters/CapitalUpdater.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import de.cesr.crafty.core.dataLoader.ProjectLoader;
 import de.cesr.crafty.core.cli.ConfigLoader;
@@ -52,14 +53,17 @@ public class CapitalUpdater extends AbstractUpdater {
 	// define the list of path will be use dusring the simulation HashMap<year,path>
 
 	private static List<String> capitalsList= new ArrayList<>();
+	private static Map<String, String> capitalTypes = new ConcurrentHashMap<>();
 	private static Map<Integer, Path> CAPITALS_directory = new TreeMap<>();
 
 	public CapitalUpdater() {
 		capitalsList = Collections.synchronizedList(new ArrayList<>());
+		capitalTypes = new ConcurrentHashMap<>();
 		Map<String, List<String>> capitalsFile = CsvProcessors
 				.ReadAsaHash(ProjectLoader.getCapitalsMetadata());
 		String label = capitalsFile.keySet().contains("Label") ? "Label" : "Name";
 		setCapitalsList(capitalsFile.get(label));
+		loadCapitalTypes(capitalsFile);
 		LOGGER.info("Capitals size=" + getCapitalsList().size() + " : " + getCapitalsList());
 		// fill the path any way
 		// <year,csv file>
@@ -99,6 +103,38 @@ public class CapitalUpdater extends AbstractUpdater {
 		LOGGER.info("Cells.updateCapitals" + path);
 		CsvProcessors.processCSV(path, CsvKind.CAPITALS);
 
+	}
+
+	private void loadCapitalTypes(Map<String, List<String>> capitalsFile) {
+		List<String> types = capitalsFile.get("Type");
+		if (types == null) {
+			if (ConfigLoader.config.separate_production_competitiveness) {
+				LOGGER.fatal("Separate production and competitiveness requires "
+						+ "the capital type to be specified in meta-data");
+			}
+			return;
+		}
+		List<String> names = getCapitalsList();
+		for (int i = 0; i < names.size() && i < types.size(); i++) {
+			String raw = types.get(i).trim();
+			if (raw.equalsIgnoreCase("Capital")) {
+				capitalTypes.put(names.get(i), "Capital");
+			} else if (raw.equalsIgnoreCase("Suitability")) {
+				capitalTypes.put(names.get(i), "Suitability");
+			} else {
+				LOGGER.warn("Unknown capital type '" + raw + "' for capital '"
+						+ names.get(i) + "', defaulting to Suitability");
+				capitalTypes.put(names.get(i), "Suitability");
+			}
+		}
+	}
+
+	public static Map<String, String> getCapitalTypes() {
+		return capitalTypes;
+	}
+
+	public static boolean isSuitability(String capitalName) {
+		return !"Capital".equals(capitalTypes.get(capitalName));
 	}
 
 	public static List<String> getCapitalsList() {

--- a/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/utils/general/DeterministicRandom.java
+++ b/CraftyProject/crafty-core/src/main/java/de/cesr/crafty/core/utils/general/DeterministicRandom.java
@@ -46,6 +46,7 @@ public final class DeterministicRandom {
         public static final int GIVE_UP_GAUSSIAN = 9;
         public static final int GIVE_UP_PROBABILITY = 10;
         public static final int GIVE_IN_THRESHOLD = 11;
+        public static final int CELL_SELECTION_TWIN_COMPETITION = 12;
 
         private Process() {
         }

--- a/CraftyProject/crafty-core/src/main/resources/config.yaml
+++ b/CraftyProject/crafty-core/src/main/resources/config.yaml
@@ -9,6 +9,7 @@ initial_demand_supply_equilibrium: true       # Ensure balanced eco-service supp
 remove_negative_marginal_utility: false       # Set marginal utility of production to 0 if negative
 use_abandonment_threshold: true               # Abandon cell if agent competitiveness falls below threshold
 mutate_on_competition_win: false              # Create new agent with mutations if competitor wins competition
+separate_production_competitiveness: false     # When true, productivity returns raw yield; competitiveness uses capital-adjusted Cobb-Douglas
 mutation_interval: 0.01                       # Interval for mutation in child agent parameters
 MostCompetitorAFTProbability: 0.8             # Probability of selecting the highest-utility AFT for cell
 averaged_residual_demand_per_cell: false      # Averaged residual demand for each cell

--- a/CraftyProject/crafty-core/src/main/resources/config.yaml
+++ b/CraftyProject/crafty-core/src/main/resources/config.yaml
@@ -10,7 +10,8 @@ remove_negative_marginal_utility: false       # Set marginal utility of producti
 use_abandonment_threshold: true               # Abandon cell if agent competitiveness falls below threshold
 mutate_on_competition_win: false              # Create new agent with mutations if competitor wins competition
 separate_production_competitiveness: false     # When true, productivity returns raw yield; competitiveness uses capital-adjusted Cobb-Douglas
-use_price_only_utility: false                  # Use price-based utility (price * production) without requiring PLUM coupling
+use_explicit_price_utility: false              # Utility = price * productivity - costs (standalone explicit-price model)
+use_price_only_utility: false                  # Utility = (price_t / price_t0) * productivity (PLUM coupling price-ratio mode)
 use_normalised_price_competition: false        # Use normalised difference competition: (uC-uO)/(|uC|+|uO|) with uC<=0 guard
 mutation_interval: 0.01                       # Interval for mutation in child agent parameters
 MostCompetitorAFTProbability: 0.8             # Probability of selecting the highest-utility AFT for cell

--- a/CraftyProject/crafty-core/src/main/resources/config.yaml
+++ b/CraftyProject/crafty-core/src/main/resources/config.yaml
@@ -27,6 +27,13 @@ participating_cells_percentage: 0.03         # Percentage of cells participating
 takeOverUnmanageCells_percentage: 0.8
 marginal_utility_calculations_per_tick: 10     # Number of times the marginal utility calculated per tick
 
+# Twinned AFTs
+# Allows a pair of AFTs (e.g. irrigated/rainfed) to compete at a separate, higher frequency.
+# Twin relationships are declared via "Twin" and "Twin_cost" columns in AFTsMetaData CSV.
+use_twinned_AFTs: false                        # Enable twinned AFT competition pass (additive to standard competition)
+use_twinned_cost: false                        # Use cost-based takeover rule instead of standard give-in dispatch
+twinned_competition_rate: 1.0                  # Fraction of eligible twin-owned cells checked per tick [0,1]
+
 # ConsiderLandControle : true/false;
 # List of landcontrole cosiderd  names    # all for all the mask will be considerd 
 # landControle directory path example [urban ; C:\Users\byari-m\Desktop\CRAFTY_DATA\CRAFTY-EU-1km_upscaled_20.0\worlds\LandUseControl\Urban] 

--- a/CraftyProject/crafty-core/src/main/resources/config.yaml
+++ b/CraftyProject/crafty-core/src/main/resources/config.yaml
@@ -10,7 +10,8 @@ remove_negative_marginal_utility: false       # Set marginal utility of producti
 use_abandonment_threshold: true               # Abandon cell if agent competitiveness falls below threshold
 mutate_on_competition_win: false              # Create new agent with mutations if competitor wins competition
 separate_production_competitiveness: false     # When true, productivity returns raw yield; competitiveness uses capital-adjusted Cobb-Douglas
-use_price_only_competition: false              # Use price-ratio utility (currentWeight/initialWeight) without requiring PLUM coupling
+use_price_only_utility: false                  # Use price-based utility (price * production) without requiring PLUM coupling
+use_normalised_price_competition: false        # Use normalised difference competition: (uC-uO)/(|uC|+|uO|) with uC<=0 guard
 mutation_interval: 0.01                       # Interval for mutation in child agent parameters
 MostCompetitorAFTProbability: 0.8             # Probability of selecting the highest-utility AFT for cell
 averaged_residual_demand_per_cell: false      # Averaged residual demand for each cell

--- a/CraftyProject/crafty-core/src/main/resources/config.yaml
+++ b/CraftyProject/crafty-core/src/main/resources/config.yaml
@@ -10,6 +10,7 @@ remove_negative_marginal_utility: false       # Set marginal utility of producti
 use_abandonment_threshold: true               # Abandon cell if agent competitiveness falls below threshold
 mutate_on_competition_win: false              # Create new agent with mutations if competitor wins competition
 separate_production_competitiveness: false     # When true, productivity returns raw yield; competitiveness uses capital-adjusted Cobb-Douglas
+use_price_only_competition: false              # Use price-ratio utility (currentWeight/initialWeight) without requiring PLUM coupling
 mutation_interval: 0.01                       # Interval for mutation in child agent parameters
 MostCompetitorAFTProbability: 0.8             # Probability of selecting the highest-utility AFT for cell
 averaged_residual_demand_per_cell: false      # Averaged residual demand for each cell

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CellTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CellTest.java
@@ -17,6 +17,7 @@ import de.cesr.crafty.core.cli.ConfigLoader;
 import de.cesr.crafty.core.dataLoader.serivces.ServiceSet;
 import de.cesr.crafty.core.output.Listener;
 import de.cesr.crafty.core.output.Tracker;
+import de.cesr.crafty.core.updaters.CapitalUpdater;
 import de.cesr.crafty.core.updaters.Timestep;
 
 class CellTest {
@@ -144,6 +145,10 @@ class CellTest {
 			setField(cfg, "separate_production_competitiveness", true);
 
 			try {
+				CapitalUpdater.getCapitalTypes().clear();
+				CapitalUpdater.getCapitalTypes().put("capA", "Suitability");
+				CapitalUpdater.getCapitalTypes().put("capB", "Capital");
+
 				Cell c = new Cell(3, 4);
 
 				Map<String, Double> caps = new ConcurrentHashMap<>();
@@ -169,10 +174,14 @@ class CellTest {
 				double prod = c.productivity(a, "S1");
 				double comp = c.competitiveness(a, "S1");
 
-				assertTrue(comp <= prod,
-						"Competitiveness (" + comp + ") should be <= production (" + prod + ") when capitals in [0,1]");
+				// prod uses only capA (Suitability): 0.5^1 * 10 = 5.0
+				// comp uses both: 0.5^1 * 0.8^2 * 10 = 3.2
+				assertEquals(5.0, prod, 1e-12);
+				assertEquals(3.2, comp, 1e-12);
+				assertTrue(comp <= prod);
 			} finally {
 				setField(cfg, "separate_production_competitiveness", false);
+				CapitalUpdater.getCapitalTypes().clear();
 			}
 		});
 	}
@@ -184,6 +193,9 @@ class CellTest {
 			setField(cfg, "separate_production_competitiveness", true);
 
 			try {
+				CapitalUpdater.getCapitalTypes().clear();
+				CapitalUpdater.getCapitalTypes().put("capA", "Suitability");
+
 				Cell c = new Cell(5, 6);
 
 				Map<String, Double> caps = new ConcurrentHashMap<>();
@@ -207,11 +219,62 @@ class CellTest {
 				double prod = c.productivity(a, "S1");
 				double comp = c.competitiveness(a, "S1");
 
-				double capitalProduct = Math.pow(4.0, 2.0);
-				double recovered = comp / capitalProduct;
-				assertEquals(prod, recovered, 1e-9, "Inverting competitiveness by capital exponents should recover production");
+				// capA is Suitability, so both methods include it — prod == comp
+				assertEquals(prod, comp, 1e-9);
 			} finally {
 				setField(cfg, "separate_production_competitiveness", false);
+				CapitalUpdater.getCapitalTypes().clear();
+			}
+		});
+	}
+
+	@Test
+	void productivity_includesSuitabilities_excludesCapitals() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setField(cfg, "separate_production_competitiveness", true);
+
+			try {
+				CapitalUpdater.getCapitalTypes().clear();
+				CapitalUpdater.getCapitalTypes().put("yield_potential", "Suitability");
+				CapitalUpdater.getCapitalTypes().put("infrastructure", "Capital");
+
+				Cell c = new Cell(7, 8);
+
+				Map<String, Double> caps = new ConcurrentHashMap<>();
+				caps.put("yield_potential", 0.6);
+				caps.put("infrastructure", 0.9);
+				setField(c, "capitals", caps);
+
+				Map<String, Double> exps = new LinkedHashMap<>();
+				exps.put("yield_potential", 1.0);
+				exps.put("infrastructure", 0.5);
+
+				Map<String, Map<String, Double>> sensByService = new ConcurrentHashMap<>();
+				sensByService.put("S1", exps);
+
+				ConcurrentHashMap<String, Double> levels = new ConcurrentHashMap<>();
+				levels.put("S1", 10.0);
+
+				Aft a = mock(Aft.class);
+				when(a.isInteract()).thenReturn(true);
+				when(a.getSensByService()).thenReturn(sensByService);
+				when(a.getProductivityLevel()).thenReturn(levels);
+
+				double prod = c.productivity(a, "S1");
+				double comp = c.competitiveness(a, "S1");
+
+				// prod: only yield_potential (Suitability): 0.6^1 * 10 = 6.0
+				assertEquals(6.0, prod, 1e-12);
+
+				// comp: both capitals: 0.6^1 * 0.9^0.5 * 10
+				assertEquals(0.6 * Math.pow(0.9, 0.5) * 10.0, comp, 1e-9);
+
+				assertTrue(comp < prod,
+						"Competitiveness should be less than production when a true Capital < 1");
+			} finally {
+				setField(cfg, "separate_production_competitiveness", false);
+				CapitalUpdater.getCapitalTypes().clear();
 			}
 		});
 	}

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CellTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CellTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import de.cesr.crafty.core.cli.ConfigLoader;
 import de.cesr.crafty.core.dataLoader.serivces.ServiceSet;
 import de.cesr.crafty.core.output.Listener;
 import de.cesr.crafty.core.output.Tracker;
@@ -98,6 +99,120 @@ class CellTest {
 
 			// expected: (2 * sqrt(9)) * 10 = (2 * 3) * 10 = 60
 			assertEquals(60.0, c.productivity(a, "S1"), 1e-12);
+		});
+	}
+
+	// -----------------------------
+	// competitiveness(...)
+	// -----------------------------
+
+	@Test
+	void competitiveness_computesExpectedProduct() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Cell c = new Cell(1, 2);
+
+			Map<String, Double> caps = new ConcurrentHashMap<>();
+			caps.put("capA", 2.0);
+			caps.put("capB", 9.0);
+			caps.put("capC", 100.0);
+			setField(c, "capitals", caps);
+
+			Map<String, Double> exps = new LinkedHashMap<>();
+			exps.put("capA", 1.0);
+			exps.put("capB", 0.5);
+			exps.put("capC", 0.0);
+
+			Map<String, Map<String, Double>> sensByService = new ConcurrentHashMap<>();
+			sensByService.put("S1", exps);
+
+			ConcurrentHashMap<String, Double> levels = new ConcurrentHashMap<>();
+			levels.put("S1", 10.0);
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getSensByService()).thenReturn(sensByService);
+			when(a.getProductivityLevel()).thenReturn(levels);
+
+			assertEquals(60.0, c.competitiveness(a, "S1"), 1e-12);
+		});
+	}
+
+	@Test
+	void competitiveness_isLessThanOrEqualToProductivity_whenCapitalsInUnitRange() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setField(cfg, "separate_production_competitiveness", true);
+
+			try {
+				Cell c = new Cell(3, 4);
+
+				Map<String, Double> caps = new ConcurrentHashMap<>();
+				caps.put("capA", 0.5);
+				caps.put("capB", 0.8);
+				setField(c, "capitals", caps);
+
+				Map<String, Double> exps = new LinkedHashMap<>();
+				exps.put("capA", 1.0);
+				exps.put("capB", 2.0);
+
+				Map<String, Map<String, Double>> sensByService = new ConcurrentHashMap<>();
+				sensByService.put("S1", exps);
+
+				ConcurrentHashMap<String, Double> levels = new ConcurrentHashMap<>();
+				levels.put("S1", 10.0);
+
+				Aft a = mock(Aft.class);
+				when(a.isInteract()).thenReturn(true);
+				when(a.getSensByService()).thenReturn(sensByService);
+				when(a.getProductivityLevel()).thenReturn(levels);
+
+				double prod = c.productivity(a, "S1");
+				double comp = c.competitiveness(a, "S1");
+
+				assertTrue(comp <= prod,
+						"Competitiveness (" + comp + ") should be <= production (" + prod + ") when capitals in [0,1]");
+			} finally {
+				setField(cfg, "separate_production_competitiveness", false);
+			}
+		});
+	}
+
+	@Test
+	void competitiveness_invertedByCapitalExponent_recoversProductivity() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setField(cfg, "separate_production_competitiveness", true);
+
+			try {
+				Cell c = new Cell(5, 6);
+
+				Map<String, Double> caps = new ConcurrentHashMap<>();
+				caps.put("capA", 4.0);
+				setField(c, "capitals", caps);
+
+				Map<String, Double> exps = new LinkedHashMap<>();
+				exps.put("capA", 2.0);
+
+				Map<String, Map<String, Double>> sensByService = new ConcurrentHashMap<>();
+				sensByService.put("S1", exps);
+
+				ConcurrentHashMap<String, Double> levels = new ConcurrentHashMap<>();
+				levels.put("S1", 5.0);
+
+				Aft a = mock(Aft.class);
+				when(a.isInteract()).thenReturn(true);
+				when(a.getSensByService()).thenReturn(sensByService);
+				when(a.getProductivityLevel()).thenReturn(levels);
+
+				double prod = c.productivity(a, "S1");
+				double comp = c.competitiveness(a, "S1");
+
+				double capitalProduct = Math.pow(4.0, 2.0);
+				double recovered = comp / capitalProduct;
+				assertEquals(prod, recovered, 1e-9, "Inverting competitiveness by capital exponents should recover production");
+			} finally {
+				setField(cfg, "separate_production_competitiveness", false);
+			}
 		});
 	}
 
@@ -240,6 +355,21 @@ class CellTest {
 	// =========================================================
 	// Helpers
 	// =========================================================
+
+	private Object ensureConfigInstance() {
+		try {
+			Field cfgField = findField(ConfigLoader.class, "config");
+			cfgField.setAccessible(true);
+			Object cfg = cfgField.get(null);
+			if (cfg == null) {
+				cfg = cfgField.getType().getDeclaredConstructor().newInstance();
+				cfgField.set(null, cfg);
+			}
+			return cfg;
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to ensure config instance", e);
+		}
+	}
 
 	/**
 	 * Runs a test body with ServiceSet.getServicesList() returning the provided

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CompetitivenessTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CompetitivenessTest.java
@@ -18,8 +18,10 @@ import de.cesr.crafty.core.dataLoader.afts.AFTsLoader;
 import de.cesr.crafty.core.dataLoader.afts.AftCategorised;
 import de.cesr.crafty.core.dataLoader.serivces.ServiceSet;
 import de.cesr.crafty.core.output.Listener;
+import de.cesr.crafty.core.output.Tracker;
 import de.cesr.crafty.core.updaters.CellBehaviourUpdater;
 import de.cesr.crafty.core.updaters.LandMaskUpdater;
+import de.cesr.crafty.core.updaters.Timestep;
 
 class CompetitivenessTest {
 
@@ -100,6 +102,7 @@ class CompetitivenessTest {
 	@Test
 	void utility_returnsZero_whenAftNullOrNotInteract() throws Throwable {
 		withServices(List.of("S1"), () -> {
+			ensureConfigInstance();
 			Cell c = new Cell(0, 0);
 			RegionalModelRunner r = mock(RegionalModelRunner.class);
 
@@ -421,6 +424,339 @@ class CompetitivenessTest {
 //        assertEquals(0.25, v, 1e-12);
 //    }
 
+	// -------------------------------------------------------
+	// landUsechangeNormalisedPriceUtility (via reflection)
+	// -------------------------------------------------------
+
+	private void callLandUsechangeNormalisedPriceUtility(Cell c, Aft competitor, RegionalModelRunner r) {
+		try {
+			Method m = Competitiveness.class.getDeclaredMethod(
+					"landUsechangeNormalisedPriceUtility", Cell.class, Aft.class, RegionalModelRunner.class);
+			m.setAccessible(true);
+			m.invoke(null, c, competitor, r);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void setupSankeyData(String aftLabel, int year) {
+		Tracker.sankeydata.computeIfAbsent(aftLabel, k -> new ConcurrentHashMap<>())
+				.computeIfAbsent(year, k -> new ConcurrentHashMap<>());
+	}
+
+	// --- Dispatch gate tests ---
+
+	@Test
+	void competition_dispatchesToNormalisedPrice_whenFlagIsTrue() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of(
+					"use_neighbor_priority", false,
+					"MostCompetitorAFTProbability", 1.0,
+					"mutate_on_competition_win", false));
+
+			setConfig(cfg, Map.of("use_normalised_price_competition", true));
+			AftCategorised.useCategorisationGivIn = false;
+			CellBehaviourUpdater.behaviourUsed = false;
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+			setOwner(c, null);
+
+			Aft competitor = mock(Aft.class);
+			when(competitor.isInteract()).thenReturn(true);
+			when(competitor.getLabel()).thenReturn("COMP");
+
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.0)));
+
+			doReturn(10.0).when(c).competitiveness(competitor, "S1");
+			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>());
+			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>());
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 10.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			r.R = region;
+
+			setupSankeyData("COMP", 2020);
+
+			try (MockedStatic<AFTsLoader> mocked = Mockito.mockStatic(AFTsLoader.class);
+			     MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+				ts.when(Timestep::getStartYear).thenReturn(2020);
+				mocked.when(AFTsLoader::getActivateAFTsHash)
+						.thenReturn(new ConcurrentHashMap<>(Map.of("COMP", competitor)));
+
+				ConfigLoader.config.use_price_only_utility = true;
+				try {
+					Competitiveness.competition(c, r);
+					assertSame(competitor, getOwner(c),
+							"Normalised price path should take over abandoned cell when uC > 0");
+					assertEquals(1, Listener.landUseChangeCounter.get());
+				} finally {
+					ConfigLoader.config.use_price_only_utility = false;
+				}
+			}
+		});
+	}
+
+	@Test
+	void competition_doesNotUseNormalisedPrice_whenFlagIsFalse() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of(
+					"use_neighbor_priority", false,
+					"MostCompetitorAFTProbability", 1.0,
+					"mutate_on_competition_win", false));
+
+			setConfig(cfg, Map.of("use_normalised_price_competition", false));
+			AftCategorised.useCategorisationGivIn = false;
+			CellBehaviourUpdater.behaviourUsed = false;
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+			setOwner(c, null);
+
+			Aft competitor = mock(Aft.class);
+			when(competitor.isInteract()).thenReturn(true);
+			when(competitor.getLabel()).thenReturn("COMP");
+
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			// marginal=1 so utility = (0+1)*6 + 0 = 6
+			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 1.0)));
+
+			doReturn(6.0).when(c).competitiveness(competitor, "S1");
+			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>());
+			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>());
+
+			ConcurrentHashMap<String, Double> meanY = new ConcurrentHashMap<>();
+			meanY.put("COMP", 5.0);
+			when(r.getDistributionMeanY()).thenReturn(meanY);
+
+			setupSankeyData("COMP", 2020);
+
+			try (MockedStatic<AFTsLoader> mocked = Mockito.mockStatic(AFTsLoader.class);
+			     MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+				mocked.when(AFTsLoader::getActivateAFTsHash)
+						.thenReturn(new ConcurrentHashMap<>(Map.of("COMP", competitor)));
+
+				Competitiveness.competition(c, r);
+				assertSame(competitor, getOwner(c),
+						"Standard landUsechange path should still work when normalised price flag is off");
+			}
+		});
+	}
+
+	// --- Normalised difference behaviour ---
+
+	@Test
+	void normalisedPrice_competitorTakesOver_whenNormDiffExceedsGiveIn() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("mutate_on_competition_win", false));
+
+			AftCategorised.useCategorisationGivIn = false;
+			CellBehaviourUpdater.behaviourUsed = false;
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft owner = mock(Aft.class);
+			when(owner.isInteract()).thenReturn(true);
+			when(owner.isAbandoned()).thenReturn(false);
+			when(owner.getLabel()).thenReturn("OWN");
+			when(owner.getGiveInMean()).thenReturn(0.1);
+			when(owner.getGiveInSD()).thenReturn(0.0);
+			setOwner(c, owner);
+			c.setCurrentUtility(2.0);
+
+			Aft competitor = mock(Aft.class);
+			when(competitor.isInteract()).thenReturn(true);
+			when(competitor.getLabel()).thenReturn("COMP");
+
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.0)));
+
+			// uC = 10. normDiff = (10-2)/(10+2) = 0.667 > giveIn 0.1
+			doReturn(10.0).when(c).competitiveness(competitor, "S1");
+			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>());
+			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>());
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 1.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			r.R = region;
+
+			setupSankeyData("COMP", 2020);
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+				ts.when(Timestep::getStartYear).thenReturn(2020);
+
+				ConfigLoader.config.use_price_only_utility = true;
+				try {
+					callLandUsechangeNormalisedPriceUtility(c, competitor, r);
+					assertSame(competitor, getOwner(c));
+				} finally {
+					ConfigLoader.config.use_price_only_utility = false;
+				}
+			}
+		});
+	}
+
+	@Test
+	void normalisedPrice_competitorDoesNotTakeOver_whenNormDiffBelowGiveIn() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("mutate_on_competition_win", false));
+
+			AftCategorised.useCategorisationGivIn = false;
+			CellBehaviourUpdater.behaviourUsed = false;
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft owner = mock(Aft.class);
+			when(owner.isInteract()).thenReturn(true);
+			when(owner.isAbandoned()).thenReturn(false);
+			when(owner.getLabel()).thenReturn("OWN");
+			when(owner.getGiveInMean()).thenReturn(0.2);
+			when(owner.getGiveInSD()).thenReturn(0.0);
+			setOwner(c, owner);
+			c.setCurrentUtility(5.0);
+
+			Aft competitor = mock(Aft.class);
+			when(competitor.isInteract()).thenReturn(true);
+			when(competitor.getLabel()).thenReturn("COMP");
+
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.0)));
+
+			// uC = 6. normDiff = (6-5)/(6+5) = 1/11 ~ 0.091 < giveIn 0.2
+			doReturn(6.0).when(c).competitiveness(competitor, "S1");
+			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>());
+			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>());
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 1.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+				ts.when(Timestep::getStartYear).thenReturn(2020);
+
+				ConfigLoader.config.use_price_only_utility = true;
+				try {
+					callLandUsechangeNormalisedPriceUtility(c, competitor, r);
+					assertSame(owner, getOwner(c),
+							"Competitor with normDiff=0.091 < giveIn=0.2 must not take over");
+					assertEquals(0, Listener.landUseChangeCounter.get());
+				} finally {
+					ConfigLoader.config.use_price_only_utility = false;
+				}
+			}
+		});
+	}
+
+	// --- Negative utility guard ---
+
+	@Test
+	void normalisedPrice_negativeUtilityDoesNotTakeOver() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("mutate_on_competition_win", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+			setOwner(c, null);
+
+			Aft competitor = mock(Aft.class);
+			when(competitor.isInteract()).thenReturn(true);
+			when(competitor.getLabel()).thenReturn("COMP");
+
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.0)));
+
+			doReturn(-5.0).when(c).competitiveness(competitor, "S1");
+			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>());
+			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>());
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 1.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+				ts.when(Timestep::getStartYear).thenReturn(2020);
+
+				ConfigLoader.config.use_price_only_utility = true;
+				try {
+					callLandUsechangeNormalisedPriceUtility(c, competitor, r);
+					assertNull(getOwner(c),
+							"Competitor with negative utility must not take over even an abandoned cell");
+					assertEquals(0, Listener.landUseChangeCounter.get());
+				} finally {
+					ConfigLoader.config.use_price_only_utility = false;
+				}
+			}
+		});
+	}
+
+	@Test
+	void normalisedPrice_negativeUtilityDoesNotTakeOver_evenWhenHigherThanOwner() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("mutate_on_competition_win", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft owner = mock(Aft.class);
+			when(owner.isInteract()).thenReturn(true);
+			when(owner.isAbandoned()).thenReturn(false);
+			when(owner.getLabel()).thenReturn("OWN");
+			when(owner.getGiveInMean()).thenReturn(0.0);
+			when(owner.getGiveInSD()).thenReturn(0.0);
+			setOwner(c, owner);
+			c.setCurrentUtility(-10.0);
+
+			Aft competitor = mock(Aft.class);
+			when(competitor.isInteract()).thenReturn(true);
+			when(competitor.getLabel()).thenReturn("COMP");
+
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.0)));
+
+			// uC = -2 (higher than uO=-10, but still negative)
+			doReturn(-2.0).when(c).competitiveness(competitor, "S1");
+			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>());
+			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>());
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 1.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+				ts.when(Timestep::getStartYear).thenReturn(2020);
+
+				ConfigLoader.config.use_price_only_utility = true;
+				try {
+					callLandUsechangeNormalisedPriceUtility(c, competitor, r);
+					assertSame(owner, getOwner(c),
+							"Competitor with uC=-2 > uO=-10 must NOT take over because uC <= 0");
+					assertEquals(0, Listener.landUseChangeCounter.get());
+				} finally {
+					ConfigLoader.config.use_price_only_utility = false;
+				}
+			}
+		});
+	}
+
 	// =========================================================
 	// Helpers
 	// =========================================================
@@ -547,4 +883,5 @@ class CompetitivenessTest {
 			throw new RuntimeException("Failed to set field '" + fieldName + "'", e);
 		}
 	}
+
 }

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CompetitivenessTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CompetitivenessTest.java
@@ -114,6 +114,177 @@ class CompetitivenessTest {
 		});
 	}
 
+	// -------------------------------------------------------
+	// utility(...) — production cost subtraction (price-only path)
+	// -------------------------------------------------------
+
+	@Test
+	void priceOnlyUtility_subtractsGlobalModeCosts_whenProductionCostsEnabled() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", true, "use_production_costs", true,
+					"spatial_production_costs", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getLabel()).thenReturn("AFT1");
+			when(a.getNfertCostPerHa()).thenReturn(10.0);
+			when(a.getIntensityCostPerHa()).thenReturn(5.0);
+
+			doReturn(2.0).when(c).competitiveness(a, "S1");
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 10.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+
+				// revenue = 10 * 2 = 20; costs = nfertCostPerHa(10) + intensityCostPerHa(5) = 15
+				assertEquals(5.0, callUtility(c, a, r), 1e-12);
+			}
+		});
+	}
+
+	@Test
+	void priceOnlyUtility_subtractsSpatialModeCosts_fromCellMaps() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", true, "use_production_costs", true,
+					"spatial_production_costs", true));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+			c.getNfertCosts().put("AFT1", 8.0);
+			c.getIntensityCosts().put("AFT1", 3.0);
+			c.getIrrigationCosts().put("AFT1", 2.0);
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getLabel()).thenReturn("AFT1");
+
+			doReturn(2.0).when(c).competitiveness(a, "S1");
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 10.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+
+				// revenue = 10 * 2 = 20; costs = nfert(8) + intensity(3) + irrigation(2) = 13
+				assertEquals(7.0, callUtility(c, a, r), 1e-12);
+			}
+		});
+	}
+
+	@Test
+	void priceOnlyUtility_noCostSubtraction_whenProductionCostsDisabled() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", true, "use_production_costs", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+			// costs present on the AFT/cell but must be ignored while the feature flag is off
+			c.getNfertCosts().put("AFT1", 8.0);
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getLabel()).thenReturn("AFT1");
+			when(a.getNfertCostPerHa()).thenReturn(10.0);
+			when(a.getIntensityCostPerHa()).thenReturn(5.0);
+
+			doReturn(2.0).when(c).competitiveness(a, "S1");
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 10.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2020);
+
+				// revenue = 10 * 2 = 20; no cost subtraction since use_production_costs=false
+				assertEquals(20.0, callUtility(c, a, r), 1e-12);
+			}
+		});
+	}
+
+	@Test
+	void marginalUtility_isUnaffectedByProductionCosts() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			// use_price_only_utility left false (default) so the marginal formula is used
+			setConfig(cfg, Map.of("use_production_costs", true, "spatial_production_costs", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getLabel()).thenReturn("AFT1");
+			when(a.getNfertCostPerHa()).thenReturn(10.0);
+			when(a.getIntensityCostPerHa()).thenReturn(5.0);
+
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 1.0)));
+
+			doReturn(6.0).when(c).competitiveness(a, "S1");
+			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>());
+			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>());
+
+			// marginal formula: (0+1)*6 + 0 = 6, unchanged despite use_production_costs=true
+			assertEquals(6.0, callUtility(c, a, r), 1e-12);
+		});
+	}
+
+	@Test
+	void dispatcher_useCellLevelTaxes_returnsMarginalWithTexesFormula() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getLabel()).thenReturn("AFT1");
+
+			doReturn(4.0).when(c).competitiveness(a, "S1");
+			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 2.0)));
+			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>(Map.of("AFT1", 3.0)));
+
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			r.initial_service_gaps = new ConcurrentHashMap<>(Map.of("S1", 5.0));
+			r.initialutilityAverage = new ConcurrentHashMap<>(Map.of("AFT1", 2.0));
+			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 1.0)));
+
+			// ConfigLoader.config is shared, mutable static state: ensureConfigInstance() reuses
+			// the existing instance rather than replacing it, so @AfterEach's reference-swap
+			// restore doesn't undo field mutations made via setConfig/direct assignment here.
+			// Flip the flag directly and always revert it, matching the convention used by the
+			// other tests in this class that mutate ConfigLoader.config fields.
+			ConfigLoader.config.use_cell_level_taxes = true;
+			try {
+				// utilityUseMarginalWithTexes: (2*5 + 1)*4 + 3*2 = 44 + 6 = 50
+				// Regression guard for the dispatcher bug where this branch's return value
+				// was discarded and utilityUseMarginal's result (6*4=24, no land-tax-average
+				// scaling) was returned instead.
+				assertEquals(50.0, callUtility(c, a, r), 1e-12);
+			} finally {
+				ConfigLoader.config.use_cell_level_taxes = false;
+			}
+		});
+	}
+
 //    @Test
 //    void utility_sumsTaxPlusMarginal_timesProductivity_plusLandTax() throws Throwable {
 //        withServices(List.of("S1", "S2"), () -> {

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CompetitivenessTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CompetitivenessTest.java
@@ -226,7 +226,7 @@ class CompetitivenessTest {
 			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.0)));
 
 			// competitor utility = 1 * 6 = 6
-			doReturn(6.0).when(c).productivity(competitor, "S1");
+			doReturn(6.0).when(c).competitiveness(competitor, "S1");
 			when(c.getLandTax()).thenReturn(new ConcurrentHashMap<>());
 			when(c.getServicesTax()).thenReturn(new ConcurrentHashMap<>());
 
@@ -274,7 +274,7 @@ class CompetitivenessTest {
 			when(r.getServiceTax()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 1.0)));
 			when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.0)));
 
-			doReturn(100.0).when(c).productivity(competitor, "S1");
+			doReturn(100.0).when(c).competitiveness(competitor, "S1");
 
 			ConcurrentHashMap<String, Double> meanY = new ConcurrentHashMap<>();
 			meanY.put(competitor.getLabel(), 0.0);

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CompetitivenessTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/CompetitivenessTest.java
@@ -64,6 +64,14 @@ class CompetitivenessTest {
 
 	@AfterEach
 	void restore() throws Exception {
+		// reset price utility flags before restoring config reference,
+		// because ensureConfigInstance() reuses the same object so
+		// @BeforeEach's snapshot and originalConfig share identity
+		if (ConfigLoader.config != null) {
+			ConfigLoader.config.use_explicit_price_utility = false;
+			ConfigLoader.config.use_price_only_utility = false;
+		}
+
 		// restore config
 		Field cfgField = findField(ConfigLoader.class, "config");
 		cfgField.setAccessible(true);
@@ -115,14 +123,14 @@ class CompetitivenessTest {
 	}
 
 	// -------------------------------------------------------
-	// utility(...) — production cost subtraction (price-only path)
+	// utility(...) — production cost subtraction (explicit-price path)
 	// -------------------------------------------------------
 
 	@Test
-	void priceOnlyUtility_subtractsGlobalModeCosts_whenProductionCostsEnabled() throws Throwable {
+	void explicitPriceUtility_subtractsGlobalModeCosts_whenProductionCostsEnabled() throws Throwable {
 		withServices(List.of("S1"), () -> {
 			Object cfg = ensureConfigInstance();
-			setConfig(cfg, Map.of("use_price_only_utility", true, "use_production_costs", true,
+			setConfig(cfg, Map.of("use_explicit_price_utility", true, "use_production_costs", true,
 					"spatial_production_costs", false));
 
 			Cell c = Mockito.spy(new Cell(0, 0));
@@ -152,10 +160,10 @@ class CompetitivenessTest {
 	}
 
 	@Test
-	void priceOnlyUtility_subtractsSpatialModeCosts_fromCellMaps() throws Throwable {
+	void explicitPriceUtility_subtractsSpatialModeCosts_fromCellMaps() throws Throwable {
 		withServices(List.of("S1"), () -> {
 			Object cfg = ensureConfigInstance();
-			setConfig(cfg, Map.of("use_price_only_utility", true, "use_production_costs", true,
+			setConfig(cfg, Map.of("use_explicit_price_utility", true, "use_production_costs", true,
 					"spatial_production_costs", true));
 
 			Cell c = Mockito.spy(new Cell(0, 0));
@@ -186,10 +194,10 @@ class CompetitivenessTest {
 	}
 
 	@Test
-	void priceOnlyUtility_noCostSubtraction_whenProductionCostsDisabled() throws Throwable {
+	void explicitPriceUtility_noCostSubtraction_whenProductionCostsDisabled() throws Throwable {
 		withServices(List.of("S1"), () -> {
 			Object cfg = ensureConfigInstance();
-			setConfig(cfg, Map.of("use_price_only_utility", true, "use_production_costs", false));
+			setConfig(cfg, Map.of("use_explicit_price_utility", true, "use_production_costs", false));
 
 			Cell c = Mockito.spy(new Cell(0, 0));
 			// costs present on the AFT/cell but must be ignored while the feature flag is off
@@ -223,7 +231,7 @@ class CompetitivenessTest {
 	void marginalUtility_isUnaffectedByProductionCosts() throws Throwable {
 		withServices(List.of("S1"), () -> {
 			Object cfg = ensureConfigInstance();
-			// use_price_only_utility left false (default) so the marginal formula is used
+			// use_explicit_price_utility left false (default) so the marginal formula is used
 			setConfig(cfg, Map.of("use_production_costs", true, "spatial_production_costs", false));
 
 			Cell c = Mockito.spy(new Cell(0, 0));
@@ -250,7 +258,7 @@ class CompetitivenessTest {
 	void dispatcher_useCellLevelTaxes_returnsMarginalWithTexesFormula() throws Throwable {
 		withServices(List.of("S1"), () -> {
 			Object cfg = ensureConfigInstance();
-			setConfig(cfg, Map.of("use_price_only_utility", false));
+			setConfig(cfg, Map.of("use_explicit_price_utility", false));
 
 			Cell c = Mockito.spy(new Cell(0, 0));
 
@@ -299,7 +307,7 @@ class CompetitivenessTest {
 //            when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.5, "S2", -2.0)));
 //
 //            // S1 productivity=2, S2 productivity=3
-//            doReturn(2.0).when(c).productivity(a, "S1");
+//            doReturn(2.0).when(c).competitiveness(a, "S1");
 //            doReturn(3.0).when(c).productivity(a, "S2");
 //
 //            // expected: (1+0.5)*2 + (10-2)*3 + 5 = 3 + 24 + 5 = 32
@@ -502,7 +510,7 @@ class CompetitivenessTest {
 //            when(r.getMarginal()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", 0.0)));
 //
 //            // competitor uC = 10
-//            doReturn(10.0).when(c).productivity(competitor, "S1");
+//            doReturn(10.0).when(c).competitiveness(competitor, "S1");
 //
 //            // nbr = mean(owner) * giveInThreshold = 2 * 1 = 2
 //            ConcurrentHashMap<Aft, Double> meanY = new ConcurrentHashMap<>();
@@ -659,14 +667,14 @@ class CompetitivenessTest {
 				mocked.when(AFTsLoader::getActivateAFTsHash)
 						.thenReturn(new ConcurrentHashMap<>(Map.of("COMP", competitor)));
 
-				ConfigLoader.config.use_price_only_utility = true;
+				ConfigLoader.config.use_explicit_price_utility = true;
 				try {
 					Competitiveness.competition(c, r);
 					assertSame(competitor, getOwner(c),
 							"Normalised price path should take over abandoned cell when uC > 0");
 					assertEquals(1, Listener.landUseChangeCounter.get());
 				} finally {
-					ConfigLoader.config.use_price_only_utility = false;
+					ConfigLoader.config.use_explicit_price_utility = false;
 				}
 			}
 		});
@@ -765,12 +773,12 @@ class CompetitivenessTest {
 				ts.when(Timestep::getCurrentYear).thenReturn(2020);
 				ts.when(Timestep::getStartYear).thenReturn(2020);
 
-				ConfigLoader.config.use_price_only_utility = true;
+				ConfigLoader.config.use_explicit_price_utility = true;
 				try {
 					callLandUsechangeNormalisedPriceUtility(c, competitor, r);
 					assertSame(competitor, getOwner(c));
 				} finally {
-					ConfigLoader.config.use_price_only_utility = false;
+					ConfigLoader.config.use_explicit_price_utility = false;
 				}
 			}
 		});
@@ -818,14 +826,14 @@ class CompetitivenessTest {
 				ts.when(Timestep::getCurrentYear).thenReturn(2020);
 				ts.when(Timestep::getStartYear).thenReturn(2020);
 
-				ConfigLoader.config.use_price_only_utility = true;
+				ConfigLoader.config.use_explicit_price_utility = true;
 				try {
 					callLandUsechangeNormalisedPriceUtility(c, competitor, r);
 					assertSame(owner, getOwner(c),
 							"Competitor with normDiff=0.091 < giveIn=0.2 must not take over");
 					assertEquals(0, Listener.landUseChangeCounter.get());
 				} finally {
-					ConfigLoader.config.use_price_only_utility = false;
+					ConfigLoader.config.use_explicit_price_utility = false;
 				}
 			}
 		});
@@ -863,14 +871,14 @@ class CompetitivenessTest {
 				ts.when(Timestep::getCurrentYear).thenReturn(2020);
 				ts.when(Timestep::getStartYear).thenReturn(2020);
 
-				ConfigLoader.config.use_price_only_utility = true;
+				ConfigLoader.config.use_explicit_price_utility = true;
 				try {
 					callLandUsechangeNormalisedPriceUtility(c, competitor, r);
 					assertNull(getOwner(c),
 							"Competitor with negative utility must not take over even an abandoned cell");
 					assertEquals(0, Listener.landUseChangeCounter.get());
 				} finally {
-					ConfigLoader.config.use_price_only_utility = false;
+					ConfigLoader.config.use_explicit_price_utility = false;
 				}
 			}
 		});
@@ -915,17 +923,158 @@ class CompetitivenessTest {
 				ts.when(Timestep::getCurrentYear).thenReturn(2020);
 				ts.when(Timestep::getStartYear).thenReturn(2020);
 
-				ConfigLoader.config.use_price_only_utility = true;
+				ConfigLoader.config.use_explicit_price_utility = true;
 				try {
 					callLandUsechangeNormalisedPriceUtility(c, competitor, r);
 					assertSame(owner, getOwner(c),
 							"Competitor with uC=-2 > uO=-10 must NOT take over because uC <= 0");
 					assertEquals(0, Listener.landUseChangeCounter.get());
 				} finally {
-					ConfigLoader.config.use_price_only_utility = false;
+					ConfigLoader.config.use_explicit_price_utility = false;
 				}
 			}
 		});
+	}
+
+	// -------------------------------------------------------
+	// utility(...) — PLUM price-ratio path (use_price_only_utility)
+	// -------------------------------------------------------
+
+	@Test
+	void priceRatioUtility_basicCalculation() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", true, "use_explicit_price_utility", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getLabel()).thenReturn("AFT1");
+			when(a.getNfertCostPerHa()).thenReturn(10.0);
+			when(a.getIntensityCostPerHa()).thenReturn(5.0);
+
+			doReturn(0.8).when(c).competitiveness(a, "S1");
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 100.0, 2025, 150.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2025);
+				ts.when(Timestep::getStartYear).thenReturn(2020);
+
+				// U = (150/100) * 0.8 = 1.2 — no cost subtraction despite costs being set
+				assertEquals(1.2, callUtility(c, a, r), 1e-12);
+			}
+		});
+	}
+
+	@Test
+	void priceRatioUtility_returnsZero_whenAftNull() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", true, "use_explicit_price_utility", false));
+
+			Cell c = new Cell(0, 0);
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+
+			assertEquals(0.0, callUtility(c, null, r), 1e-12);
+		});
+	}
+
+	@Test
+	void priceRatioUtility_returnsZero_whenAftNotInteract() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", true, "use_explicit_price_utility", false));
+
+			Cell c = new Cell(0, 0);
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(false);
+			assertEquals(0.0, callUtility(c, a, r), 1e-12);
+		});
+	}
+
+	@Test
+	void priceRatioUtility_handlesZeroInitialWeight() throws Throwable {
+		withServices(List.of("S1"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", true, "use_explicit_price_utility", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getLabel()).thenReturn("AFT1");
+
+			doReturn(0.5).when(c).competitiveness(a, "S1");
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 0.0, 2025, 100.0)));
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1)));
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2025);
+				ts.when(Timestep::getStartYear).thenReturn(2020);
+
+				// Infinity from 100/0 → clamped to 0 by NaN/Inf guard → total = 0
+				assertEquals(0.0, callUtility(c, a, r), 1e-12);
+			}
+		});
+	}
+
+	@Test
+	void priceRatioUtility_multipleServices() throws Throwable {
+		withServices(List.of("S1", "S2"), () -> {
+			Object cfg = ensureConfigInstance();
+			setConfig(cfg, Map.of("use_price_only_utility", true, "use_explicit_price_utility", false));
+
+			Cell c = Mockito.spy(new Cell(0, 0));
+
+			Aft a = mock(Aft.class);
+			when(a.isInteract()).thenReturn(true);
+			when(a.getLabel()).thenReturn("AFT1");
+
+			doReturn(2.0).when(c).competitiveness(a, "S1");
+			doReturn(3.0).when(c).competitiveness(a, "S2");
+
+			Service s1 = mock(Service.class);
+			when(s1.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 100.0, 2025, 200.0)));
+			Service s2 = mock(Service.class);
+			when(s2.getWeights()).thenReturn(new ConcurrentHashMap<>(Map.of(2020, 50.0, 2025, 75.0)));
+
+			Region region = mock(Region.class);
+			when(region.getServicesHash()).thenReturn(new ConcurrentHashMap<>(Map.of("S1", s1, "S2", s2)));
+			RegionalModelRunner r = mock(RegionalModelRunner.class);
+			r.R = region;
+
+			try (MockedStatic<Timestep> ts = Mockito.mockStatic(Timestep.class)) {
+				ts.when(Timestep::getCurrentYear).thenReturn(2025);
+				ts.when(Timestep::getStartYear).thenReturn(2020);
+
+				// S1: (200/100)*2 = 4.0;  S2: (75/50)*3 = 4.5;  total = 8.5
+				assertEquals(8.5, callUtility(c, a, r), 1e-12);
+			}
+		});
+	}
+
+	@Test
+	void configValidation_bothPriceUtilityFlags_shouldBeInvalid() throws Throwable {
+		Object cfg = ensureConfigInstance();
+		setConfig(cfg, Map.of("use_explicit_price_utility", true, "use_price_only_utility", true));
+
+		// The combination is invalid — in the real code validatePriceUtilityConfig() calls LOGGER.fatal()
+		assertTrue(ConfigLoader.config.use_explicit_price_utility);
+		assertTrue(ConfigLoader.config.use_price_only_utility);
 	}
 
 	// =========================================================

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/RegionalModelRunnerTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/RegionalModelRunnerTest.java
@@ -168,8 +168,8 @@ class RegionalModelRunnerTest {
 			setField(c, "owner", owner);
 			setField(cNull, "owner", null);
 
-			// productivity(owner,"S1") = 10
-			doReturn(10.0).when(c).productivity(owner, "S1");
+			// competitiveness(owner,"S1") = 10
+			doReturn(10.0).when(c).competitiveness(owner, "S1");
 
 			ConcurrentHashMap<String, Cell> cells = new ConcurrentHashMap<>();
 			cells.put("0,0", c);

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/RegionalModelRunnerTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/crafty/RegionalModelRunnerTest.java
@@ -60,6 +60,12 @@ class RegionalModelRunnerTest {
 
 	@AfterEach
 	void restoreStatics() throws Exception {
+		// reset price utility flags before restoring config reference
+		if (ConfigLoader.config != null) {
+			ConfigLoader.config.use_explicit_price_utility = false;
+			ConfigLoader.config.use_price_only_utility = false;
+		}
+
 		// restore ConfigLoader.config
 		Field cfgField = findField(ConfigLoader.class, "config");
 		cfgField.setAccessible(true);

--- a/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/updaters/CapitalUpdaterTest.java
+++ b/CraftyProject/crafty-core/src/test/java/de/cesr/crafty/core/updaters/CapitalUpdaterTest.java
@@ -74,4 +74,35 @@ class CapitalUpdaterTest {
 		assertTrue(capitals.contains("capi1"));
 		assertTrue(capitals.contains("capi3"));
 	}
+
+	@Test
+	void isSuitability_returnsTrueForSuitabilityType() {
+		CapitalUpdater.getCapitalTypes().clear();
+		CapitalUpdater.getCapitalTypes().put("ExtC3C_suit", "Suitability");
+		CapitalUpdater.getCapitalTypes().put("soil_quality", "Capital");
+
+		assertTrue(CapitalUpdater.isSuitability("ExtC3C_suit"));
+		assertFalse(CapitalUpdater.isSuitability("soil_quality"));
+	}
+
+	@Test
+	void isSuitability_returnsTrueForUnknownCapital() {
+		CapitalUpdater.getCapitalTypes().clear();
+
+		assertTrue(CapitalUpdater.isSuitability("never_seen_before"));
+	}
+
+	@Test
+	void capitalTypes_storageWorksCorrectly() {
+		CapitalUpdater.getCapitalTypes().clear();
+		CapitalUpdater.getCapitalTypes().put("capi1", "Capital");
+		CapitalUpdater.getCapitalTypes().put("capi2", "Suitability");
+		CapitalUpdater.getCapitalTypes().put("capi3", "Suitability");
+
+		assertEquals("Capital", CapitalUpdater.getCapitalTypes().get("capi1"));
+		assertEquals("Suitability", CapitalUpdater.getCapitalTypes().get("capi2"));
+		assertFalse(CapitalUpdater.isSuitability("capi1"));
+		assertTrue(CapitalUpdater.isSuitability("capi2"));
+		assertTrue(CapitalUpdater.isSuitability("capi3"));
+	}
 }

--- a/CraftyProject/crafty-plum/src/main/java/main/MainCoupling.java
+++ b/CraftyProject/crafty-plum/src/main/java/main/MainCoupling.java
@@ -40,6 +40,7 @@ public class MainCoupling {
 
 		MainHeadless.initializeConfig(args);
 		ConfigLoader.config.COUPLED_WITH_PLUM = true;
+		ConfigLoader.config.use_price_only_competition = true;
 		PathTools.makeDirectory(ConfigLoader.config.plumOutPutPath + File.separator + "crafty");
 		ProjectLoader.pathInitialisation(Paths.get(ConfigLoader.config.project_path));
 		MainHeadless.runner = new ModelRunner();


### PR DESCRIPTION
# This PR contains 3 new features. 

1) Separating production & competitiveness
2) Adding production costs to the price-based utility
3) Twinned AFTs

# 1) Separating Production and Competitiveness

## Overview

In the original CRAFTY model, a single Cobb-Douglas function served both as the measure of an AFT's competitive utility on a cell and as its production output. All capitals (biophysical suitability, infrastructure, social capital, etc.) entered the same calculation.

This feature separates these into two distinct concepts:

- **Competitiveness** — the full Cobb-Douglas product using *all* capitals. Used for utility calculation and land-use competition.
- **Productivity** — a Cobb-Douglas product using only *suitability* capitals. Used for actual production output (what appears in CSVs, maps, and supply tracking).

We distinguish between "Capitals" [socio-economic capitals] and "Suitabilities" [yield potentials]. Competitiveness is impacted by both Capitals and Suitabilities (as at present). Production is only impacted by Suitabilities. 

The rationale is that non-suitability capitals (e.g., infrastructure, market access) influence whether an AFT *can compete* for a cell, but the physical yield of that cell depends on biophysical factors and management choices. If an AFT *can* gain access to the required capitals - they produce. 

## Config

In `config.yaml`:

```yaml
separate_production_competitiveness: false
```

- `false` (default): productivity delegates to competitiveness — the original single-function behaviour.
- `true`: productivity filters to suitability capitals only; competitiveness continues to use all capitals.

## How it works

## CSV setup

### Capitals metadata CSV

When `separate_production_competitiveness: true`, the capitals metadata file **must** include a `Type` column. Without it, the model raises a fatal error.

| Label | Type | ... |
|---|---|---|
| soil_quality | Suitability | |
| climate_suit | Suitability | |
| infrastructure | Capital | |
| market_access | Capital | |

Valid type values:
- `Suitability` — included in both productivity and competitiveness
- `Capital` — included in competitiveness only, excluded from productivity

Unknown type values default to `Suitability` with a warning. If the `Type` column is present but `separate_production_competitiveness` is false, the column is loaded but has no effect.


### Competitiveness (unchanged)

For a given cell, AFT, and service:

```
competitiveness = productivityLevel(service) × ∏(all capitals) capitalValue^sensitivity
```

Where `capitalValue = baseCapital × (1 + capitalAdjustment)` and `sensitivity` is the Cobb-Douglas exponent for that capital-service pair.

If an AFT has no sensitivity entries for a service, competitiveness returns **0.0**.

This is always used for:
- Utility calculation (all utility methods: marginal, price-based, tax-based)
- Land-use competition decisions

### Productivity (when flag is true)

```
productivity = productivityLevel(service) × ∏(suitability capitals only) capitalValue^sensitivity
```

Non-suitability capitals (those typed as `Capital` in the metadata) are skipped entirely.

If an AFT has no sensitivity entries for a service, productivity returns **productivityLevel** (the base coefficient) rather than 0.0. This means an AFT can still produce even if it has no suitability sensitivities defined for a particular service.

This is used for:
- Cell CSV output (the service columns like `C3cereals`, `C3starchyroots`, etc.)
- Tracker aggregation (regional supply/demand calculations)
- PNG/map output

### When the flag is false

`productivity()` delegates directly to `competitiveness()` — both methods return the same value, and the model behaves identically to the original.

### AFT sensitivity CSVs

No changes required. The existing sensitivity/exponent CSVs define capital-service pairs as before. The filtering happens at runtime based on capital type.

## Summary

| | `separate_production_competitiveness: false` | `separate_production_competitiveness: true` |
|---|---|---|
| Productivity | Same as competitiveness (all capitals) | Suitability capitals only |
| Competitiveness | All capitals | All capitals (unchanged) |
| Utility/competition | Uses competitiveness | Uses competitiveness (unchanged) |
| Output CSVs/maps | Full Cobb-Douglas values | Suitability-only values |
| Capitals CSV | `Type` column optional | `Type` column required |

## Testing

In addition to unit tests, a macro-scale test of model behaviour was conducted. This demonstrates that for any given service, the produced amount for a given cell is always 0 or a linear scaling of its suitability (productionRate * suitability).

Here this is shown for extensive C3 cereals. 

<img width="1444" height="716" alt="image" src="https://github.com/user-attachments/assets/b83f47d5-705f-4abf-a872-6ba101c9f327" />

# 2) Production Costs

## Overview

This feature adds production cost subtraction to the utility calculation. Costs represent the expense of agricultural production (fertiliser, irrigation, intensity of management) and are subtracted from revenue to give a net utility. Currently this is designed for agricultural AFTs, though the framework will be extended to pasture AFTs (harvest rate, intensity of mgmt) & forestry (rotation length as intensity of mgmt cost).

For cropland AFTs there are three cost types:
- **Nitrogen fertiliser (Nfert)** — cost of fertiliser application, based on an application rate per AFT
- **Irrigation** — cost of irrigation water use, applied to irrigated AFTs
- **Intensity** — cost reflecting the intensity of land management, scaled by an AFT's production levels

Costs can operate in two modes:
- **Global** — costs are computed once at initialisation from a single global cost file plus AFT metadata
- **Spatial** — costs vary by cell and year, loaded from per-year CSV files

## Config

In `config.yaml`:

```yaml
use_production_costs: false
spatial_production_costs: false
```

- `use_production_costs: false` (default): no costs are subtracted from utility.
- `use_production_costs: true`: enables cost subtraction.
- `spatial_production_costs: true`: uses per-cell, per-year cost CSVs instead of global values. Requires `use_production_costs: true` (validated at startup — setting spatial without the master switch is a fatal error).

An optional `costs_directory` field can override where cost files are searched for.

## How costs enter utility

Production costs are **only subtracted in the `use_explicit_price_utility` path**:

```
Utility = Σ_s [ price_s × competitiveness(cell, aft, s) ] − productionCost(cell, aft)
```

The other utility methods (marginal, marginal-with-taxes, Mohamed's CRAFTY-PLUM price-ratio) do **not** subtract production costs.

## Cost calculation

`Cell.productionCost(Aft a)` for cropland AFTs computes:

```
totalCost = irrigationCost + nfertCost + intensityCost
```

- **Irrigation** is always read from the cell-level map (`cell.irrigationCosts`), even in global mode. This is because irrigation cost is inherently spatial due to water availability (this is based on the PLUM method).
- In **global mode**, nfert and intensity costs come from the AFT object (pre-computed at init).
- In **spatial mode**, all three come from per-cell maps, reloaded each simulation year.

## Which AFTs get which costs

AFT eligibility for each cost type is determined by the AFT's category and metadata:

| Cost type | Eligible AFTs | Determination |
|---|---|---|
| Nfert | Category = `Agri_Crops` | Category name from AFTsMetaData |
| Irrigation | `Irrigated = 1` | Irrigated column in AFTsMetaData |
| Intensity | Category ≠ `Uncategorized` AND ≠ `Natural` | Category name from AFTsMetaData |

## Global mode detail

### global_costs.csv

Required whenever `use_production_costs: true`. Located in the costs directory. Format:

| Item | Cost |
|---|---|
| Nfert | 1.5 |
| C3cereals | 200 |
| C3starchyroots | 150 |
| ... | ... |

- The row with `Item = Nfert` provides the unit cost per kg N.
- All other rows are intensity costs, keyed by service name [i.e. C3 cereals is the PLUM other intensity cost of C3 cereal production].

### Nfert cost (global)

Computed once at initialisation for each `Agri_Crops` AFT:

```
aft.nfertCostPerHa = nfertUnitCost × aft.nfertRate
```

Where `nfertRate` is loaded from the `Nfert_rate` column of AFTsMetaData.

### Intensity cost (global)

Computed once at initialisation for each eligible AFT:

```
aft.intensityCostPerHa = Σ_s [ aft.productivityLevel(s) × intensityCost(s) ]
```

This scales the per-service intensity cost by the AFT's base productivity for each service.

### Irrigation cost (global)

Loaded from a static irrigation CSV (one file, not per-year) into per-cell maps. Format is either:

- Single column: `X, Y, IRRIGATION_COST` — the same value is applied to all irrigated AFTs
- Per-AFT columns: `X, Y, AFT1, AFT2, ...` — different costs per irrigated AFT

## Spatial mode detail

In spatial mode, all three cost types are loaded from per-year CSV files and stored in per-cell maps. Files are reloaded each simulation year.

### File naming and location

Files are searched for in the costs directory (or `worlds/production_costs/` by default) with the scenario name. Expected filenames:

- `Nfert_costs_{year}.csv` — in a `Nfert/` subdirectory
- `Irrigation_costs_{year}.csv` — in an `irrigation/` subdirectory
- `Intensity_costs_{year}.csv` — in an `intensity/` subdirectory

All three must exist for every year in the simulation range, or the model raises a fatal error.

### Spatial CSV format

All spatial cost CSVs share the same structure:

| X | Y | AFT_Label_1 | AFT_Label_2 | ... |
|---|---|---|---|---|
| 0 | 0 | 120.5 | 0.0 | ... |
| 1 | 0 | 115.3 | 45.2 | ... |

Column headers after X and Y must match AFT labels. Only AFTs eligible for that cost type need columns (e.g., only `Agri_Crops` AFTs need Nfert columns). The irrigation CSV can alternatively use a single `IRRIGATION_COST` column that applies uniformly to all irrigated AFTs.

## AFTsMetaData CSV columns

The following columns in AFTsMetaData are relevant to production costs:

| Column | Type | Description |
|---|---|---|
| `Nfert_rate` | Double | Nitrogen fertiliser application rate (kg N/ha). Used in global mode to compute per-AFT nfert cost. |
| `Irrigated` | Integer (0/1) | Whether this AFT uses irrigation. Determines irrigation cost eligibility. |

## Summary

| Aspect | Global mode | Spatial mode |
|---|---|---|
| Nfert | `unitCost × nfertRate`, stored on AFT | Per-cell, per-year CSV |
| Irrigation | Static spatial CSV, stored on cells | Per-year CSV, stored on cells |
| Intensity | `Σ(prodLevel × serviceCost)`, stored on AFT | Per-cell, per-year CSV |
| Files needed | `global_costs.csv` + one irrigation CSV | `global_costs.csv` + 3 CSVs per year |
| When reloaded | Once at init | Each simulation year |
| Utility path | `use_explicit_price_utility` only | `use_explicit_price_utility` only |

## Testing

In addition to unit tests a macro-level check was done on model behaviour. We reproduced the expected AFT calculations for agri-crops AFTs in R, checking we achieved the same utility. Calculations are reproduced perfectly.

<img width="814" height="754" alt="image" src="https://github.com/user-attachments/assets/0924a447-6ecb-4ec7-a6b4-967182c4484f" />

# 3) Twinned AFTs

## Overview

The twinned AFTs feature allows pairs of related AFTs to compete against each other in a dedicated competition pass that runs in addition to the standard CRAFTY competition. This gives twin pairs a higher effective competition frequency without increasing the rate of general land-use competition.

### Initial use case: irrigated vs. rainfed agriculture

The primary motivation is modelling irrigation decisions. An irrigated and rainfed variant of the same crop type (e.g., `IntC3C_irrig` and `IntC3C`) are declared as twins. Each timestep, cells occupied by one twin are evaluated for whether the other twin would be more competitive — effectively asking "should this cell switch from rainfed to irrigated (or vice versa)?" at a frequency independent of the broader land-use competition.

This allows the irrigation decision to be revisited frequently without destabilising other land-use transitions. More broadly, it allows smaller land use decisions to be made more frequently than more dramatic ones. 

This could be supplemented in future with "cousins" - AFTs within a group, e.g., agri-crops & intensity level = 3. This would allow a farmer to switch from maize to soybeans and back again (as is frequently done in the USA cornbelt) more frequently than converting to conservation woodland, and back.

## Config

In `config.yaml`:

```yaml
use_twinned_AFTs: false
use_twinned_cost: false
twinned_competition_rate: 1.0
```

| Option | Type | Default | Description |
|---|---|---|---|
| `use_twinned_AFTs` | boolean | `false` | Master switch. Enables the twin competition pass. |
| `use_twinned_cost` | boolean | `false` | When true, uses a cost-threshold takeover rule instead of the standard give-in dispatch. Requires `use_twinned_AFTs: true`. |
| `twinned_competition_rate` | double | `1.0` | Fraction of eligible twin-owned cells checked per tick, in [0, 1]. At 1.0 every eligible cell is checked every tick. |

### Validation

- `use_twinned_cost: true` with `use_twinned_AFTs: false` is a fatal error.
- `twinned_competition_rate` outside [0, 1] is a fatal error.

## How it works

### Step ordering

Twin competition runs as its own step in `RegionalModelRunner.step()`, in this sequence:

1. Compute regional supply
2. Compute marginal utilities
3. Utility for all cells
4. **Twinned competition** ← here
5. Give-up (abandonment)
6. Take over unmanaged cells
7. Standard competition

This means twins get an additional competition pass on top of the standard one.

### Cell selection

Each tick, cells are filtered for twin competition eligibility:

1. Cell has a non-null, interacting owner
2. That owner has a declared twin (`hasTwin()` is true)
3. A deterministic random coin flip passes, using `twinned_competition_rate` as the probability

The random selection uses `DeterministicRandom` with a dedicated process code (`CELL_SELECTION_TWIN_COMPETITION`), ensuring reproducibility from a seed derived from the run seed, current year, and cell coordinates.

Selected cells are split into subsets (using the same `marginal_utility_calculations_per_tick` setting as standard competition). Between sub-iterations, regional supply is updated and marginal utilities are recomputed.

### Competition logic

For each selected cell, only the owner's declared twin is tested as the competitor — not the full set of AFTs.

Before competition proceeds, standard guards apply:
- The twin must not be the same as the current owner
- Mask-based restrictions must allow the transition
- The owner must have been on the cell for at least `min_life_cycle` ticks (if no mask)

Then one of two takeover rules applies:

#### Cost-based rule (`use_twinned_cost: true`)

```
if (uTwin > 0) AND (uTwin > uOwner + twinCost):
    twin takes over
```

- `uTwin` is the twin's utility on the cell (computed fresh)
- `uOwner` is the current owner's cached utility on the cell
- `twinCost` is a fixed cost threshold declared per AFT in metadata

This is a deterministic, direct comparison with a cost barrier. The twin must have positive utility AND exceed the owner's utility by at least the declared twin cost. E.g. the twinCost could be an estimate of the cost of installing irrigation.

#### Dispatch-based rule (`use_twinned_cost: false`, default)

The twin is passed to the same `dispatchLandUseChange` logic used by standard competition. Depending on other config flags, this routes to:

- `landUsechangeNormalisedPriceUtility` (if `use_normalised_price_competition: true`)
- `landUsechangeNormalisedUtility` (if categorisation give-in and cell behaviour are both active)
- `landUsechange` (default give-in threshold with stochastic component)

This means twin competition uses the same takeover rules as general competition, just applied only to the twin pair.

### After takeover

When a twin takes over a cell:
- The cell's owner is set to the twin
- The cell's utility is recalculated
- The cell's production (`currentProd[]`) is recalculated
- Regional supply is updated with the production change
- The transition is recorded in land-use change counters and Sankey tracking data

## CSV setup

### AFTsMetaData CSV

Two columns declare twin relationships:

| Column | Type | Required | Description |
|---|---|---|---|
| `Twin` | String | When `use_twinned_AFTs: true` | Label of this AFT's twin partner. Empty or missing = no twin. |
| `Twin_cost` | Double | When `use_twinned_cost: true` | Cost threshold for the cost-based takeover rule. |

If `use_twinned_AFTs` is true but the `Twin` column is missing from the CSV, the model raises a fatal error. Similarly for `use_twinned_cost` and the `Twin_cost` column.

### Example AFTsMetaData entries

| Label | Type | ... | Twin | Twin_cost |
|---|---|---|---|---|
| IntC3C | interact | ... | IntC3C_irrig | 50 |
| IntC3C_irrig | interact | ... | IntC3C | 50 |
| ExtC3C | interact | ... | | |
| Natural | non_interact | ... | | |

Key rules enforced at load time:
- An AFT cannot name itself as its own twin (cleared with a warning)
- A twin that references a non-existent AFT label is cleared with a warning
- A twin that references a non-interacting AFT is cleared with a warning
- Twin relationships do not need to be symmetric, but typically are (both AFTs name each other); i.e. rainfed could twin to irrigated, but not viceversa. (Once irrigation is installed, we wouldn't uninstall it).

## Design notes

- Twin competition is **additive** to standard competition — it does not replace it. A cell that undergoes a twin switch can still be competed for by other AFTs in the standard competition pass later in the same tick.
- The `twinned_competition_rate` parameter allows tuning how frequently twin decisions are revisited. At 1.0 (default), every eligible cell is checked every tick. At lower values, a deterministic subset is selected — useful if twin competition is computationally expensive or if the switching decision should be less frequent.
- The cost-based rule (`use_twinned_cost`) gives more direct control over switching thresholds, while the dispatch-based rule reuses the existing competition infrastructure with its stochastic give-in mechanisms.

### Testing

In addition to unit tests, macro-level testing used a test suite in which capitals were held constant for 10 ticks. Twins were set to have obvious competitive advantages (most irrigated AFTs much worse, but IntC3C irrigated had -5 on all capital sensitivities).

This failed at first because cells were abandoned which would otherwise have twinned. I thought that it made sense to see if adopting your twin would make it worth continuing (i.e. before giving up) so moved the twin competition before abandoning. 

With this in place all transitions occured as planned: 

<img width="1420" height="242" alt="image" src="https://github.com/user-attachments/assets/63b817a1-316a-4ee7-b5bd-a7a592fc39f3" />

